### PR TITLE
Add genesis boot-phase script

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -32,6 +32,7 @@ Implementing full-stack web environment. Initialized Next.js app with Prisma and
 
 ### Testing
 - Verify Next.js app starts and connects to database
+- Validate `scripts/genesis_boot.sh` initialization script
 
 ### Expansion
 - Integrate Python API routes with Next.js front end

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -46,6 +46,7 @@ This file tracks all project dependencies, their relationships, and integration 
 - **Prompt Files**: Executable workflow templates in `.github/prompts/`
 - **Instruction Files**: Coding standards and guidelines in `.github/instructions/`
 - **Script System**: Automation tools in `scripts/` directory
+- **Genesis Boot-Phase Script**: Checks Node dependencies, container state, and Git repo
 
 ### Project Structure Dependencies
 - **TypeScript Runtime**: Core language support in `src/`

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -25,6 +25,7 @@ This file tracks what works, what remains to be built, current status, and known
 - Autonomous state manager tracks changes
 - Multipurpose initialization system under `init/`
 - Enhanced prompt generator and context-aware templates
+- Genesis boot-phase script for dependency checks and environment validation
 
 ### Docs
 - Repository documentation updated to reference new rules
@@ -36,6 +37,7 @@ This file tracks what works, what remains to be built, current status, and known
 ## What's Left
 
 - **Test Conditional Python Framework**: Run each environment mode (local, docker_isolated, docker_volume) to validate complete functionality
+- **Test Genesis Boot-Phase Script**: Validate package manager detection and environment checks across OS/container setups
 - **Document Framework Lessons**: Capture learnings about conditional instruction design for future language environments
 - **Extend Conditional Framework**: Consider applying conditional approach to Node.js, TypeScript, and other language setups
 - **Complete Web Authentication**: Finalize login flows and database migrations

--- a/scripts/genesis_boot.sh
+++ b/scripts/genesis_boot.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# genesis_boot.sh: Minimal genesis boot-phase checks
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+install_deps() {
+  local dir="$1"
+  local pm=""
+  if [ -f "$dir/pnpm-lock.yaml" ]; then
+    pm="pnpm"
+  elif [ -f "$dir/package-lock.json" ] || [ -f "$dir/npm-shrinkwrap.json" ]; then
+    pm="npm"
+  elif [ -f "$dir/yarn.lock" ]; then
+    pm="yarn"
+  else
+    pm="npm"
+  fi
+
+  if [ "$pm" = "pnpm" ] && [ -f "$dir/pnpm-workspace.yaml" ]; then
+    log "pnpm workspace detected in $dir"
+  fi
+
+  log "Installing dependencies in $dir with $pm"
+  (cd "$dir" && "$pm" install)
+}
+
+check_node_dir() {
+  local pkg_file="$1"
+  local dir
+  dir="$(dirname "$pkg_file")"
+  if [ ! -d "$dir/node_modules" ]; then
+    log "node_modules missing in $dir"
+    install_deps "$dir"
+  else
+    log "node_modules already present in $dir"
+  fi
+
+  if [ -d "$dir/node_modules" ]; then
+    log "Dependencies installed for $dir"
+  else
+    log "[ERROR] Dependency installation failed in $dir"
+  fi
+}
+
+main() {
+  local pkg_files
+  pkg_files=$(find . -maxdepth 2 -name package.json -not -path '*/node_modules/*')
+  if [ -z "$pkg_files" ]; then
+    log "No package.json found"
+  else
+    while IFS= read -r pkg; do
+      check_node_dir "$pkg"
+    done <<< "$pkg_files"
+  fi
+
+  if [ -f /.dockerenv ] || [ "${CI:-}" = "true" ]; then
+    log "Running inside container"
+  else
+    log "Running on host"
+  fi
+
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    log "Git branch: $branch"
+    git status --short
+  else
+    log "Not a git repository"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- implement `genesis_boot.sh` for minimal setup
- track the new script in memory bank docs
- list follow-up testing in progress and active context

## Testing
- `markdownlint --config .markdownlint.yaml memory-bank/progress.md memory-bank/dependencies.md memory-bank/activeContext.md`
- `scripts/verify-all.sh` *(fails: unknown option `--strict`)*

------
https://chatgpt.com/codex/tasks/task_e_68477b0edda48331b1bd67cb08cff599