### PR TITLE
Implement rate limiter and 429 handling

### DIFF
--- a/memory-bank/activeContext.log.md
+++ b/memory-bank/activeContext.log.md
@@ -6,3 +6,4 @@
 
 - [2025-06-13T19:58:36Z] Started SDK core bootstrap from Implementation Playbook; unzipping skipped (file absent). Created branch feat/sdk-core-bootstrap. Planning to restructure TS code to Questrade SDK core per blueprint.
 - [2025-06-13T21:22:19Z] Removed pnpm-lock.yaml and added rule to avoid lock files; updated AGENTS.md with no-lock-files preference and activeContext with decision note.
+- [2025-06-13T22:45:12Z] Implemented rate limiter hourly buckets and 429 handling in TokenBucketLimiter and RestClient. Updated markdown check script. Verification failing due to existing lint errors.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,7 +17,7 @@ This file tracks the current work focus, recent changes, next steps, and active 
 
 ## Current Work Focus
 
-Implementing full-stack web environment. Initialized Next.js app with Prisma and PostgreSQL using script-driven setup. Preparing integration with existing Python services.
+Finishing Questrade SDK core features. Implemented hourly rate-limit buckets with 429 back-off logic while continuing web integration work.
 
 ## Recent Changes
 
@@ -26,6 +26,7 @@ Implementing full-stack web environment. Initialized Next.js app with Prisma and
 - **Login Feature**: Created simple login API routes using Prisma and bcrypt.
 - **Ledger Protocol**: Added Memory Bank ledger instructions to `AGENTS.md` and
   updated documentation for markdownlint compliance.
+- **Rate Limit Patch**: Added hourly token buckets and 429 handling logic in SDK core.
 
 ## Next Steps
 
@@ -33,10 +34,12 @@ Implementing full-stack web environment. Initialized Next.js app with Prisma and
 - Document Prisma and PostgreSQL dependencies in `memory-bank/dependencies.md`
 - Record web architecture in `memory-bank/systemPatterns.md`
 - Update `memory-bank/progress.md` with web environment status
+- Note rate limiter patch in `memory-bank/progress.md`
 
 ### Testing
 - Verify Next.js app starts and connects to database
 - Validate `scripts/genesis_boot.sh` initialization script
+- Run unit tests for updated rate limiter
 
 ### Expansion
 - Integrate Python API routes with Next.js front end

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -33,6 +33,7 @@ This file tracks what works, what remains to be built, current status, and known
 - Python standards instruction file published
 - VS Code settings updated for Copilot 1.101+
 - Next.js app scaffolded with Prisma integration
+- SDK Rate Limiter with hourly buckets and 429 back-off logic
 
 <!-- ai:section:whats-left -->
 ## What's Left
@@ -42,6 +43,7 @@ This file tracks what works, what remains to be built, current status, and known
 - **Document Framework Lessons**: Capture learnings about conditional instruction design for future language environments
 - **Extend Conditional Framework**: Consider applying conditional approach to Node.js, TypeScript, and other language setups
 - **Complete Web Authentication**: Finalize login flows and database migrations
+- **Wire SDK 429 Errors**: Connect error handler to rate limiter for header sync
 - Review all Memory Bank and .clinerules files for cross-reference and compliance with the new code organization standard.
 - Verify markdown-lint compliance for all updated documentation.
 - Communicate the new standard to all contributors and ensure script-driven enforcement.

--- a/scripts/check-markdown.sh
+++ b/scripts/check-markdown.sh
@@ -7,7 +7,7 @@ log() {
 
 log "Running markdownlint on all tracked markdown files"
 files=$(git ls-files '*.md')
-pnpm exec markdownlint --config .markdownlint.yaml "$files" || {
+pnpm exec markdownlint --config .markdownlint.yaml $files || {
   echo "[ERROR] markdownlint failed"
   exit 1
 }

--- a/src/http/restClient.ts
+++ b/src/http/restClient.ts
@@ -22,8 +22,17 @@ export class RestClient {
     });
     this.limiter.hydrate('account', {
       'x-ratelimit-remaining': res.headers.get('x-ratelimit-remaining') ?? '',
-      'x-ratelimit-reset': res.headers.get('x-ratelimit-reset') ?? ''
+      'x-ratelimit-reset': res.headers.get('x-ratelimit-reset') ?? '',
+      'x-ratelimit-remaining-second': res.headers.get('x-ratelimit-remaining-second') ?? '',
+      'x-ratelimit-reset-second': res.headers.get('x-ratelimit-reset-second') ?? '',
+      'x-ratelimit-remaining-hour': res.headers.get('x-ratelimit-remaining-hour') ?? '',
+      'x-ratelimit-reset-hour': res.headers.get('x-ratelimit-reset-hour') ?? ''
     });
+    if (res.status === 429) {
+      const reset = Number(res.headers.get('x-ratelimit-reset') ?? '0');
+      if (!Number.isNaN(reset)) this.limiter.handle429('account', reset);
+      throw new Error('Rate limit exceeded');
+    }
     if (!res.ok) return handleQuestradeError(res);
     return res.json() as Promise<T>;
   }

--- a/src/rateLimit/interfaces.ts
+++ b/src/rateLimit/interfaces.ts
@@ -1,8 +1,13 @@
 export type BucketKind = 'account' | 'market';
 
-export interface RateLimitBucket {
+export interface TokenBucket {
   capacity: number;
   refillInterval: number; // ms
   remaining: number;
   reset: number; // epoch ms
+}
+
+export interface RateLimitGroup {
+  perSecond: TokenBucket;
+  perHour: TokenBucket;
 }

--- a/src/rateLimit/tokenBucket.ts
+++ b/src/rateLimit/tokenBucket.ts
@@ -1,28 +1,62 @@
-import { BucketKind, RateLimitBucket } from './interfaces';
+import { BucketKind, RateLimitGroup } from './interfaces';
+import { RULES } from './rules';
 
 export class TokenBucketLimiter {
-  private buckets: Record<BucketKind, RateLimitBucket> = {
-    account: { capacity: 30, refillInterval: 1000, remaining: 30, reset: Date.now() },
-    market: { capacity: 20, refillInterval: 1000, remaining: 20, reset: Date.now() }
+  private buckets: Record<BucketKind, RateLimitGroup> = {
+    account: {
+      perSecond: { capacity: RULES.account.rps, refillInterval: 1000, remaining: RULES.account.rps, reset: Date.now() },
+      perHour: { capacity: RULES.account.rph, refillInterval: 3600_000, remaining: RULES.account.rph, reset: Date.now() }
+    },
+    market: {
+      perSecond: { capacity: RULES.market.rps, refillInterval: 1000, remaining: RULES.market.rps, reset: Date.now() },
+      perHour: { capacity: RULES.market.rph, refillInterval: 3600_000, remaining: RULES.market.rph, reset: Date.now() }
+    }
   };
 
   async consume(kind: BucketKind): Promise<void> {
-    while (this.buckets[kind].remaining <= 0) {
-      const delay = this.buckets[kind].reset - Date.now();
+    const group = this.buckets[kind];
+    while (group.perSecond.remaining <= 0 || group.perHour.remaining <= 0) {
+      const delay = Math.min(
+        group.perSecond.reset - Date.now(),
+        group.perHour.reset - Date.now()
+      );
       await new Promise((r) => setTimeout(r, Math.max(delay, 50)));
+      this.refill(group);
     }
-    this.buckets[kind].remaining -= 1;
+    group.perSecond.remaining -= 1;
+    group.perHour.remaining -= 1;
   }
 
   hydrate(kind: BucketKind, headers: Record<string, string>): void {
-    const rem = Number(headers['x-ratelimit-remaining']);
-    const reset = Number(headers['x-ratelimit-reset']) * 1000;
-    if (!Number.isNaN(rem)) this.buckets[kind].remaining = rem;
-    if (!Number.isNaN(reset)) this.buckets[kind].reset = reset;
+    const group = this.buckets[kind];
+    const secondRem = Number(headers['x-ratelimit-remaining-second'] ?? headers['x-ratelimit-remaining']);
+    const secondReset = Number(headers['x-ratelimit-reset-second'] ?? headers['x-ratelimit-reset']) * 1000;
+    const hourRem = Number(headers['x-ratelimit-remaining-hour']);
+    const hourReset = Number(headers['x-ratelimit-reset-hour']) * 1000;
+
+    if (!Number.isNaN(secondRem)) group.perSecond.remaining = secondRem;
+    if (!Number.isNaN(secondReset)) group.perSecond.reset = secondReset;
+    if (!Number.isNaN(hourRem)) group.perHour.remaining = hourRem;
+    if (!Number.isNaN(hourReset)) group.perHour.reset = hourReset;
   }
 
   handle429(kind: BucketKind, reset: number): void {
-    this.buckets[kind].remaining = 0;
-    this.buckets[kind].reset = reset * 1000;
+    const group = this.buckets[kind];
+    group.perSecond.remaining = 0;
+    group.perHour.remaining = 0;
+    group.perSecond.reset = reset * 1000;
+    group.perHour.reset = reset * 1000;
+  }
+
+  private refill(group: RateLimitGroup): void {
+    const now = Date.now();
+    if (now >= group.perSecond.reset) {
+      group.perSecond.remaining = group.perSecond.capacity;
+      group.perSecond.reset = now + group.perSecond.refillInterval;
+    }
+    if (now >= group.perHour.reset) {
+      group.perHour.remaining = group.perHour.capacity;
+      group.perHour.reset = now + group.perHour.refillInterval;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add hourly token buckets with refill logic
- handle 429 responses in `RestClient`
- update markdown check script
- log rate limit patch in memory bank

## Testing
- `bash scripts/verify-all.sh` *(fails: markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ca6b4c5e0833187747f1fe18a3796