### PR TITLE
Add Questrade type definitions and schemas

### DIFF
--- a/scripts/setup_questrade_types.sh
+++ b/scripts/setup_questrade_types.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# setup_questrade_types.sh: scaffold Questrade type modules
+set -euo pipefail
+
+log(){ echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"; }
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+TYPES_DIR="src/types"
+FILES=(enums.ts accounts.ts orders.ts markets.ts symbols.ts responses.ts index.ts)
+
+if [ ! -d "$TYPES_DIR" ]; then
+  mkdir -p "$TYPES_DIR"
+  log "Created directory $TYPES_DIR"
+else
+  log "Directory $TYPES_DIR already exists"
+fi
+
+for f in "${FILES[@]}"; do
+  path="$TYPES_DIR/$f"
+  if [ ! -f "$path" ]; then
+    echo "// auto-generated placeholder" > "$path"
+    log "Created $path"
+  else
+    log "File $path already exists"
+  fi
+done
+
+log "Questrade type module scaffold complete"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './client/QuestradeClient';
 export * from './auth/interfaces';
 export * from './auth/manager';
 export * from './http/restClient';
+export * from './types';

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+import {
+  AccountTypeSchema,
+  AccountStatusSchema,
+  ClientAccountTypeSchema,
+  CurrencySchema,
+  AccountType,
+  AccountStatus,
+  ClientAccountType,
+  Currency
+} from './enums';
+
+/** Basic account information */
+export interface Account {
+  number: string;
+  type: AccountType;
+  status: AccountStatus;
+  isPrimary: boolean;
+  isBilling: boolean;
+  clientAccountType: ClientAccountType;
+}
+
+/** Zod schema for {@link Account} */
+export const AccountSchema = z.object({
+  number: z.string(),
+  type: AccountTypeSchema,
+  status: AccountStatusSchema,
+  isPrimary: z.boolean(),
+  isBilling: z.boolean(),
+  clientAccountType: ClientAccountTypeSchema
+});
+
+/** Per-currency balance information */
+export interface Balance {
+  currency: Currency;
+  cash: number;
+  marketValue: number;
+  totalEquity: number;
+  buyingPower: number;
+  maintenanceExcess: number;
+  isRealTime: boolean;
+}
+
+/** Zod schema for {@link Balance} */
+export const BalanceSchema = z.object({
+  currency: CurrencySchema,
+  cash: z.number(),
+  marketValue: z.number(),
+  totalEquity: z.number(),
+  buyingPower: z.number(),
+  maintenanceExcess: z.number(),
+  isRealTime: z.boolean()
+});
+
+/** Position in an account */
+export interface Position {
+  symbol: string;
+  symbolId: number;
+  openQuantity: number;
+  closedQuantity: number;
+  currentMarketValue: number;
+  currentPrice: number;
+  averageEntryPrice: number;
+  closedPnl: number;
+  openPnl: number;
+  totalCost: number;
+  isRealTime: boolean;
+  isUnderReorg: boolean;
+}
+
+/** Zod schema for {@link Position} */
+export const PositionSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  openQuantity: z.number(),
+  closedQuantity: z.number(),
+  currentMarketValue: z.number(),
+  currentPrice: z.number(),
+  averageEntryPrice: z.number(),
+  closedPnl: z.number(),
+  openPnl: z.number(),
+  totalCost: z.number(),
+  isRealTime: z.boolean(),
+  isUnderReorg: z.boolean()
+});
+
+
+/** Execution fill within an account */
+export interface Execution {
+  symbol: string;
+  symbolId: number;
+  quantity: number;
+  side: OrderAction;
+  price: number;
+  id: number;
+  orderId: number;
+  orderChainId: number;
+  exchangeExecId: string;
+  timestamp: string;
+  notes: string;
+  venue: string;
+  totalCost: number;
+  orderPlacementCommission: number;
+  commission: number;
+  executionFee: number;
+  secFee: number;
+  canadianExecutionFee: number;
+  parentId: number;
+}
+
+export const ExecutionSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  quantity: z.number().int(),
+  side: OrderActionSchema,
+  price: z.number(),
+  id: z.number().int(),
+  orderId: z.number().int(),
+  orderChainId: z.number().int(),
+  exchangeExecId: z.string(),
+  timestamp: z.string(),
+  notes: z.string(),
+  venue: z.string(),
+  totalCost: z.number(),
+  orderPlacementCommission: z.number(),
+  commission: z.number(),
+  executionFee: z.number(),
+  secFee: z.number(),
+  canadianExecutionFee: z.number().int(),
+  parentId: z.number().int()
+});
+
+/** Entry in account activity log */
+export interface AccountActivity {
+  tradeDate: string;
+  transactionDate: string;
+  settlementDate: string;
+  action: string;
+  symbol: string;
+  symbolId: number;
+  description: string;
+  currency: Currency;
+  quantity: number;
+  price: number;
+  grossAmount: number;
+  commission: number;
+  netAmount: number;
+  type: string;
+}
+
+export const AccountActivitySchema = z.object({
+  tradeDate: z.string(),
+  transactionDate: z.string(),
+  settlementDate: z.string(),
+  action: z.string(),
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  description: z.string(),
+  currency: CurrencySchema,
+  quantity: z.number(),
+  price: z.number(),
+  grossAmount: z.number(),
+  commission: z.number(),
+  netAmount: z.number(),
+  type: z.string()
+});

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+
+/** Supported currency codes */
+export type Currency = 'USD' | 'CAD';
+export const CurrencySchema = z.enum(['USD', 'CAD']);
+
+/** Listing exchanges for securities */
+export type ListingExchange =
+  | 'TSX' | 'TSXV' | 'CNSX' | 'MX'
+  | 'NASDAQ' | 'NYSE' | 'NYSEAM' | 'ARCA'
+  | 'OPRA' | 'PinkSheets' | 'OTCBB';
+export const ListingExchangeSchema = z.enum([
+  'TSX','TSXV','CNSX','MX','NASDAQ','NYSE','NYSEAM','ARCA','OPRA','PinkSheets','OTCBB'
+]);
+
+/** Account types */
+export type AccountType =
+  | 'Cash' | 'Margin'
+  | 'TFSA' | 'RRSP' | 'FHSA' | 'SRRSP' | 'LRRSP'
+  | 'LIRA' | 'LIF' | 'RIF' | 'SRIF' | 'LRIF'
+  | 'RRIF' | 'PRIF'
+  | 'RESP' | 'FRESP';
+export const AccountTypeSchema = z.enum([
+  'Cash','Margin','TFSA','RRSP','FHSA','SRRSP','LRRSP',
+  'LIRA','LIF','RIF','SRIF','LRIF','RRIF','PRIF','RESP','FRESP'
+]);
+
+/** Client account holder types */
+export type ClientAccountType =
+  | 'Individual' | 'Joint' | 'Informal Trust'
+  | 'Corporation' | 'Formal Trust' | 'Partnership'
+  | 'Sole Proprietorship' | 'Family'
+  | 'Joint and Informal Trust' | 'Institution';
+export const ClientAccountTypeSchema = z.enum([
+  'Individual','Joint','Informal Trust','Corporation','Formal Trust',
+  'Partnership','Sole Proprietorship','Family','Joint and Informal Trust','Institution'
+]);
+
+/** Account status values */
+export type AccountStatus =
+  | 'Active'
+  | 'Suspended (Closed)'
+  | 'Suspended (View Only)'
+  | 'Liquidate Only'
+  | 'Closed';
+export const AccountStatusSchema = z.enum([
+  'Active','Suspended (Closed)','Suspended (View Only)','Liquidate Only','Closed'
+]);
+
+/** Tick directions */
+export type TickType = 'Up' | 'Down' | 'Equal';
+export const TickTypeSchema = z.enum(['Up','Down','Equal']);
+
+/** Option contract types */
+export type OptionType = 'Call' | 'Put';
+export const OptionTypeSchema = z.enum(['Call','Put']);
+
+/** Option duration cycles */
+export type OptionDurationType = 'Weekly' | 'Monthly' | 'Quarterly' | 'LEAP';
+export const OptionDurationTypeSchema = z.enum(['Weekly','Monthly','Quarterly','LEAP']);
+
+/** Option exercise style */
+export type OptionExerciseType = 'American' | 'European';
+export const OptionExerciseTypeSchema = z.enum(['American','European']);
+
+/** Security types */
+export type SecurityType = 'Stock' | 'Option' | 'Bond' | 'Right' | 'Gold' | 'MutualFund' | 'Index';
+export const SecurityTypeSchema = z.enum(['Stock','Option','Bond','Right','Gold','MutualFund','Index']);
+
+/** Order state filter */
+export type OrderStateFilter = 'All' | 'Open' | 'Closed';
+export const OrderStateFilterSchema = z.enum(['All','Open','Closed']);
+
+/** Order actions */
+export type OrderAction = 'Buy' | 'Sell';
+export const OrderActionSchema = z.enum(['Buy','Sell']);
+
+/** Extended order sides */
+export type OrderSide = 'Buy' | 'Sell' | 'Short' | 'Cov' | 'BTO' | 'STC' | 'STO' | 'BTC';
+export const OrderSideSchema = z.enum(['Buy','Sell','Short','Cov','BTO','STC','STO','BTC']);
+
+/** Order types */
+export type OrderType =
+  | 'Market' | 'Limit' | 'Stop' | 'StopLimit'
+  | 'TrailStopInPercentage' | 'TrailStopInDollar'
+  | 'TrailStopLimitInPercentage' | 'TrailStopLimitInDollar'
+  | 'LimitOnOpen' | 'LimitOnClose';
+export const OrderTypeSchema = z.enum([
+  'Market','Limit','Stop','StopLimit',
+  'TrailStopInPercentage','TrailStopInDollar',
+  'TrailStopLimitInPercentage','TrailStopLimitInDollar',
+  'LimitOnOpen','LimitOnClose'
+]);
+
+/** Time in force values */
+export type TimeInForce =
+  | 'Day' | 'GoodTillCanceled' | 'GoodTillExtendedDay'
+  | 'GoodTillDate' | 'ImmediateOrCancel' | 'FillOrKill';
+export const TimeInForceSchema = z.enum([
+  'Day','GoodTillCanceled','GoodTillExtendedDay',
+  'GoodTillDate','ImmediateOrCancel','FillOrKill'
+]);
+
+/** Order lifecycle states */
+export type OrderState =
+  | 'Failed' | 'Pending' | 'Accepted' | 'Rejected'
+  | 'CancelPending' | 'Canceled' | 'PartialCanceled'
+  | 'Partial' | 'Executed' | 'ReplacePending' | 'Replaced'
+  | 'Stopped' | 'Suspended' | 'Expired' | 'Queued'
+  | 'Triggered' | 'Activated' | 'PendingRiskReview'
+  | 'ContingentOrder';
+export const OrderStateSchema = z.enum([
+  'Failed','Pending','Accepted','Rejected',
+  'CancelPending','Canceled','PartialCanceled',
+  'Partial','Executed','ReplacePending','Replaced',
+  'Stopped','Suspended','Expired','Queued',
+  'Triggered','Activated','PendingRiskReview','ContingentOrder'
+]);
+
+/** Candle intervals */
+export type CandleInterval =
+  | 'OneMinute' | 'TwoMinutes' | 'ThreeMinutes' | 'FourMinutes' | 'FiveMinutes'
+  | 'TenMinutes' | 'FifteenMinutes' | 'TwentyMinutes'
+  | 'HalfHour' | 'OneHour' | 'TwoHours' | 'FourHours'
+  | 'OneDay' | 'OneWeek' | 'OneMonth' | 'OneYear';
+export const CandleIntervalSchema = z.enum([
+  'OneMinute','TwoMinutes','ThreeMinutes','FourMinutes','FiveMinutes',
+  'TenMinutes','FifteenMinutes','TwentyMinutes',
+  'HalfHour','OneHour','TwoHours','FourHours',
+  'OneDay','OneWeek','OneMonth','OneYear'
+]);
+
+/** Bracket order classes */
+export type OrderClass = 'Primary' | 'Limit' | 'StopLoss';
+export const OrderClassSchema = z.enum(['Primary','Limit','StopLoss']);
+
+/** Option strategy types */
+export type StrategyType =
+  | 'CoveredCall' | 'MarriedPuts'
+  | 'VerticalCallSpread' | 'VerticalPutSpread'
+  | 'CalendarCallSpread' | 'CalendarPutSpread'
+  | 'DiagonalCallSpread' | 'DiagonalPutSpread'
+  | 'Collar' | 'Straddle' | 'Strangle'
+  | 'ButterflyCall' | 'ButterflyPut'
+  | 'IronButterfly' | 'CondorCall'
+  | 'Custom';
+export const StrategyTypeSchema = z.enum([
+  'CoveredCall','MarriedPuts','VerticalCallSpread','VerticalPutSpread',
+  'CalendarCallSpread','CalendarPutSpread','DiagonalCallSpread','DiagonalPutSpread',
+  'Collar','Straddle','Strangle','ButterflyCall','ButterflyPut',
+  'IronButterfly','CondorCall','Custom'
+]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,6 @@
+export * from './enums';
+export * from './accounts';
+export * from './orders';
+export * from './markets';
+export * from './symbols';
+export * from './responses';

--- a/src/types/markets.ts
+++ b/src/types/markets.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+import { Currency, CurrencySchema } from './enums';
+
+/** Market trading configuration */
+export interface Market {
+  name: string;
+  tradingVenues: string[];
+  defaultTradingVenue: string;
+  primaryOrderRoutes: string[];
+  secondaryOrderRoutes: string[];
+  level1Feeds: string[];
+  level2Feeds: string[];
+  extendedStartTime: string;
+  startTime: string;
+  endTime: string;
+  extendedEndTime: string;
+  currency: Currency;
+  snapQuotesLimit: number;
+}
+
+/** Zod schema for {@link Market} */
+export const MarketSchema = z.object({
+  name: z.string(),
+  tradingVenues: z.array(z.string()),
+  defaultTradingVenue: z.string(),
+  primaryOrderRoutes: z.array(z.string()),
+  secondaryOrderRoutes: z.array(z.string()),
+  level1Feeds: z.array(z.string()),
+  level2Feeds: z.array(z.string()),
+  extendedStartTime: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  extendedEndTime: z.string(),
+  currency: CurrencySchema,
+  snapQuotesLimit: z.number().int()
+});
+
+/** Quote for equities and other instruments */
+export interface Quote {
+  symbol: string;
+  symbolId: number;
+  tier: string;
+  bidPrice: number | null;
+  bidSize: number | null;
+  askPrice: number | null;
+  askSize: number | null;
+  lastTradePrice: number | null;
+  lastTradePriceTrHrs: number | null;
+  lastTradeSize: number | null;
+  lastTradeTick: string | null;
+  lastTradeTime: string | null;
+  volume: number | null;
+  openPrice: number | null;
+  highPrice: number | null;
+  lowPrice: number | null;
+  vwap: number | null;
+  isDelayed: boolean;
+}
+
+/** Zod schema for {@link Quote} */
+export const QuoteSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  tier: z.string(),
+  bidPrice: z.number().nullable(),
+  bidSize: z.number().nullable(),
+  askPrice: z.number().nullable(),
+  askSize: z.number().nullable(),
+  lastTradePrice: z.number().nullable(),
+  lastTradePriceTrHrs: z.number().nullable(),
+  lastTradeSize: z.number().nullable(),
+  lastTradeTick: z.string().nullable(),
+  lastTradeTime: z.string().nullable(),
+  volume: z.number().nullable(),
+  openPrice: z.number().nullable(),
+  highPrice: z.number().nullable(),
+  lowPrice: z.number().nullable(),
+  vwap: z.number().nullable(),
+  isDelayed: z.boolean()
+});
+
+/** Option quote with Greeks */
+export interface OptionQuote extends Quote {
+  underlying: string;
+  underlyingId: number;
+  expiryDate: string;
+  strikePrice: number;
+  optionType: string;
+  volatility: number | null;
+  delta: number | null;
+  gamma: number | null;
+  theta: number | null;
+  vega: number | null;
+  rho: number | null;
+  openInterest: number | null;
+}
+
+/** Zod schema for {@link OptionQuote} */
+export const OptionQuoteSchema = QuoteSchema.extend({
+  underlying: z.string(),
+  underlyingId: z.number().int(),
+  expiryDate: z.string(),
+  strikePrice: z.number(),
+  optionType: z.string(),
+  volatility: z.number().nullable(),
+  delta: z.number().nullable(),
+  gamma: z.number().nullable(),
+  theta: z.number().nullable(),
+  vega: z.number().nullable(),
+  rho: z.number().nullable(),
+  openInterest: z.number().nullable()
+});
+
+/** Strategy quote for option strategies */
+export interface StrategyQuote {
+  variantId: number;
+  bidPrice: number | null;
+  askPrice: number | null;
+  underlying: string;
+  underlyingId: number;
+}
+
+/** Zod schema for {@link StrategyQuote} */
+export const StrategyQuoteSchema = z.object({
+  variantId: z.number().int(),
+  bidPrice: z.number().nullable(),
+  askPrice: z.number().nullable(),
+  underlying: z.string(),
+  underlyingId: z.number().int()
+});
+
+/** OHLC candle */
+export interface Candle {
+  start: string;
+  end: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/** Zod schema for {@link Candle} */
+export const CandleSchema = z.object({
+  start: z.string(),
+  end: z.string(),
+  open: z.number(),
+  high: z.number(),
+  low: z.number(),
+  close: z.number(),
+  volume: z.number()
+});

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+import {
+  OrderSide,
+  OrderType,
+  TimeInForce,
+  OrderState,
+  OrderAction,
+  StrategyType,
+  OrderClass,
+  OrderSideSchema,
+  OrderTypeSchema,
+  TimeInForceSchema,
+  OrderStateSchema,
+  OrderActionSchema,
+  StrategyTypeSchema,
+  OrderClassSchema
+} from './enums';
+
+/** A single leg of a multi-leg order */
+export interface OrderLeg {
+  strategyType: StrategyType;
+  triggerStopPrice: number | null;
+  orderGroupId: number;
+  orderClass: OrderClass;
+}
+
+/** Zod schema for {@link OrderLeg} */
+export const OrderLegSchema = z.object({
+  strategyType: StrategyTypeSchema,
+  triggerStopPrice: z.number().nullable(),
+  orderGroupId: z.number().int(),
+  orderClass: OrderClassSchema
+});
+
+/** Detailed order information */
+export interface Order {
+  id: number;
+  symbol: string;
+  symbolId: number;
+  totalQuantity: number;
+  openQuantity: number;
+  filledQuantity: number;
+  canceledQuantity: number;
+  side: OrderSide;
+  orderType: OrderType;
+  limitPrice: number | null;
+  stopPrice: number | null;
+  isAllOrNone: boolean;
+  isAnonymous: boolean;
+  icebergQuantity: number | null;
+  minQuantity: number | null;
+  avgExecPrice: number | null;
+  lastExecPrice: number | null;
+  source: string;
+  timeInForce: TimeInForce;
+  gtdDate: string | null;
+  state: OrderState;
+  clientReasonStr: string;
+  chainId: number;
+  creationTime: string;
+  updateTime: string;
+  notes: string;
+  primaryRoute: string;
+  secondaryRoute: string;
+  orderRoute: string;
+  venueHoldingOrder: string;
+  commissionCharged: number;
+  exchangeOrderId: string;
+  isSignificantShareholder: boolean;
+  isInsider: boolean;
+  isLimitOffsetInDollar: boolean;
+  userId: number;
+  placementCommission: number;
+  legs?: OrderLeg[];
+}
+
+/** Zod schema for {@link Order} */
+export const OrderSchema = z.object({
+  id: z.number().int(),
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  totalQuantity: z.number(),
+  openQuantity: z.number(),
+  filledQuantity: z.number(),
+  canceledQuantity: z.number(),
+  side: OrderSideSchema,
+  orderType: OrderTypeSchema,
+  limitPrice: z.number().nullable(),
+  stopPrice: z.number().nullable(),
+  isAllOrNone: z.boolean(),
+  isAnonymous: z.boolean(),
+  icebergQuantity: z.number().nullable(),
+  minQuantity: z.number().nullable(),
+  avgExecPrice: z.number().nullable(),
+  lastExecPrice: z.number().nullable(),
+  source: z.string(),
+  timeInForce: TimeInForceSchema,
+  gtdDate: z.string().nullable(),
+  state: OrderStateSchema,
+  clientReasonStr: z.string(),
+  chainId: z.number().int(),
+  creationTime: z.string(),
+  updateTime: z.string(),
+  notes: z.string(),
+  primaryRoute: z.string(),
+  secondaryRoute: z.string(),
+  orderRoute: z.string(),
+  venueHoldingOrder: z.string(),
+  commissionCharged: z.number(),
+  exchangeOrderId: z.string(),
+  isSignificantShareholder: z.boolean(),
+  isInsider: z.boolean(),
+  isLimitOffsetInDollar: z.boolean(),
+  userId: z.number().int(),
+  placementCommission: z.number(),
+  legs: z.array(OrderLegSchema).optional()
+});

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+import { Account, AccountSchema, Balance, BalanceSchema, Position, PositionSchema, Execution, ExecutionSchema, AccountActivity, AccountActivitySchema } from './accounts';
+import { Order, OrderSchema } from './orders';
+import { Market, MarketSchema, Quote, QuoteSchema, OptionQuote, OptionQuoteSchema, StrategyQuote, StrategyQuoteSchema, Candle, CandleSchema } from './markets';
+import { SymbolDetail, SymbolDetailSchema, SymbolSearchResult, SymbolSearchResultSchema, ChainPerExpiryDate, OptionChainSchema } from './symbols';
+
+/** Response from GET /accounts */
+export interface AccountsResponse {
+  accounts: Account[];
+  userId: number;
+}
+export const AccountsResponseSchema = z.object({
+  accounts: z.array(AccountSchema),
+  userId: z.number().int()
+});
+
+/** Response from GET /accounts/:id/balances */
+export interface AccountBalancesResponse {
+  perCurrencyBalances: Balance[];
+  combinedBalances: Balance[];
+  sodPerCurrencyBalances: Balance[];
+  sodCombinedBalances: Balance[];
+}
+export const AccountBalancesResponseSchema = z.object({
+  perCurrencyBalances: z.array(BalanceSchema),
+  combinedBalances: z.array(BalanceSchema),
+  sodPerCurrencyBalances: z.array(BalanceSchema),
+  sodCombinedBalances: z.array(BalanceSchema)
+});
+
+/** Response from GET /accounts/:id/positions */
+export interface PositionsResponse {
+  positions: Position[];
+}
+export const PositionsResponseSchema = z.object({
+  positions: z.array(PositionSchema)
+});
+
+/** Response from GET /accounts/:id/executions */
+export interface ExecutionsResponse {
+  executions: Execution[];
+}
+export const ExecutionsResponseSchema = z.object({
+  executions: z.array(ExecutionSchema)
+});
+
+/** Response from GET /accounts/:id/activities */
+export interface ActivitiesResponse {
+  activities: AccountActivity[];
+}
+export const ActivitiesResponseSchema = z.object({
+  activities: z.array(AccountActivitySchema)
+});
+
+/** Response from GET /accounts/:id/orders */
+export interface OrdersResponse {
+  orders: Order[];
+}
+export const OrdersResponseSchema = z.object({
+  orders: z.array(OrderSchema)
+});
+
+export type OrderResponse = OrdersResponse;
+export const OrderResponseSchema = OrdersResponseSchema;
+
+/** Response from GET /time */
+export interface TimeResponse {
+  time: string;
+}
+export const TimeResponseSchema = z.object({
+  time: z.string()
+});
+
+/** Response from GET /markets */
+export interface MarketsResponse {
+  markets: Market[];
+}
+export const MarketsResponseSchema = z.object({
+  markets: z.array(MarketSchema)
+});
+
+/** Response from GET quotes endpoints */
+export interface QuotesResponse {
+  quotes: Quote[];
+}
+export const QuotesResponseSchema = z.object({
+  quotes: z.array(QuoteSchema)
+});
+
+/** Response from GET option quotes */
+export interface OptionQuotesResponse {
+  optionQuotes: OptionQuote[];
+}
+export const OptionQuotesResponseSchema = z.object({
+  optionQuotes: z.array(OptionQuoteSchema)
+});
+
+/** Response from GET strategy quotes */
+export interface StrategyQuotesResponse {
+  strategyQuotes: StrategyQuote[];
+}
+export const StrategyQuotesResponseSchema = z.object({
+  strategyQuotes: z.array(StrategyQuoteSchema)
+});
+
+/** Response from GET candles */
+export interface CandlesResponse {
+  candles: Candle[];
+}
+export const CandlesResponseSchema = z.object({
+  candles: z.array(CandleSchema)
+});
+
+/** Response from GET symbols */
+export interface SymbolsResponse {
+  symbols: SymbolDetail[];
+}
+export const SymbolsResponseSchema = z.object({
+  symbols: z.array(SymbolDetailSchema)
+});
+
+/** Response from GET symbols search */
+export interface SymbolSearchResponse {
+  symbols: SymbolSearchResult[];
+}
+export const SymbolSearchResponseSchema = z.object({
+  symbols: z.array(SymbolSearchResultSchema)
+});
+
+/** Response from GET option chain */
+export interface OptionsChainResponse {
+  options: ChainPerExpiryDate[];
+}
+export const OptionsChainResponseSchema = OptionChainSchema;

--- a/src/types/symbols.ts
+++ b/src/types/symbols.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod';
+import {
+  ListingExchange,
+  ListingExchangeSchema,
+  OptionType,
+  OptionDurationType,
+  OptionExerciseType,
+  SecurityType,
+  OptionTypeSchema,
+  OptionDurationTypeSchema,
+  OptionExerciseTypeSchema,
+  SecurityTypeSchema
+} from './enums';
+
+/** Underlying deliverable component */
+export interface OptionDeliverable {
+  underlyingSymbol: string;
+  underlyingSymbolId: number;
+  multiplier: number;
+}
+
+/** Minimum tick info */
+export interface MinTick {
+  pivot: number;
+  minTick: number;
+}
+
+/** Option deliverables grouping */
+export interface OptionDeliverables {
+  underlyings: OptionDeliverable[];
+  cashInLieu: number;
+}
+
+/** Detailed symbol information */
+export interface SymbolDetail {
+  symbol: string;
+  symbolId: number;
+  prevDayClosePrice: number;
+  highPrice52: number;
+  lowPrice52: number;
+  averageVol3Months: number;
+  averageVol20Days: number;
+  outstandingShares: number;
+  eps: number;
+  pe: number;
+  dividend: number;
+  yield: number;
+  exDate: string | null;
+  marketCap: number;
+  tradeUnit: number;
+  optionType: OptionType | null;
+  optionDurationType: OptionDurationType | null;
+  optionRoot: string;
+  optionContractDeliverables: OptionDeliverables;
+  optionExerciseType: OptionExerciseType | null;
+  listingExchange: ListingExchange;
+  description: string;
+  securityType: SecurityType;
+  optionExpiryDate: string | null;
+  dividendDate: string | null;
+  optionStrikePrice: number | null;
+  isTradable: boolean;
+  isQuotable: boolean;
+  hasOptions: boolean;
+  minTicks: MinTick[];
+  industrySector: string;
+  industryGroup: string;
+  industrySubGroup: string;
+}
+
+/** Zod schema for {@link SymbolDetail} */
+export const SymbolDetailSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  prevDayClosePrice: z.number(),
+  highPrice52: z.number(),
+  lowPrice52: z.number(),
+  averageVol3Months: z.number().int(),
+  averageVol20Days: z.number().int(),
+  outstandingShares: z.number().int(),
+  eps: z.number(),
+  pe: z.number(),
+  dividend: z.number(),
+  yield: z.number(),
+  exDate: z.string().nullable(),
+  marketCap: z.number(),
+  tradeUnit: z.number().int(),
+  optionType: OptionTypeSchema.nullable(),
+  optionDurationType: OptionDurationTypeSchema.nullable(),
+  optionRoot: z.string(),
+  optionContractDeliverables: z.object({
+    underlyings: z.array(z.object({
+      multiplier: z.number().int(),
+      underlyingSymbol: z.string(),
+      underlyingSymbolId: z.number().int()
+    })),
+    cashInLieu: z.number()
+  }),
+  optionExerciseType: OptionExerciseTypeSchema.nullable(),
+  listingExchange: ListingExchangeSchema,
+  description: z.string(),
+  securityType: SecurityTypeSchema,
+  optionExpiryDate: z.string().nullable(),
+  dividendDate: z.string().nullable(),
+  optionStrikePrice: z.number().nullable(),
+  isTradable: z.boolean(),
+  isQuotable: z.boolean(),
+  hasOptions: z.boolean(),
+  minTicks: z.array(z.object({ pivot: z.number(), minTick: z.number() })),
+  industrySector: z.string(),
+  industryGroup: z.string(),
+  industrySubGroup: z.string()
+});
+
+/** Result from symbol search */
+export interface SymbolSearchResult {
+  symbol: string;
+  symbolId: number;
+  description: string;
+  securityType: SecurityType;
+  listingExchange: ListingExchange;
+  isTradable: boolean;
+  isQuotable: boolean;
+}
+
+/** Zod schema for {@link SymbolSearchResult} */
+export const SymbolSearchResultSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  description: z.string(),
+  securityType: SecurityTypeSchema,
+  listingExchange: ListingExchangeSchema,
+  isTradable: z.boolean(),
+  isQuotable: z.boolean()
+});
+
+/** Option chain structures */
+export interface ChainPerStrikePrice {
+  strikePrice: number;
+  callSymbolId: number;
+  putSymbolId: number;
+}
+
+export interface ChainPerRoot {
+  root: string;
+  multiplier: number;
+  chainPerStrikePrice: ChainPerStrikePrice[];
+}
+
+export interface ChainPerExpiryDate {
+  expiryDate: string;
+  description: string;
+  listingExchange: ListingExchange;
+  optionExerciseType: OptionExerciseType;
+  chainPerRoot: ChainPerRoot[];
+}
+
+export interface OptionChain {
+  options: ChainPerExpiryDate[];
+}
+
+/** Zod schema for {@link OptionChain} */
+export const OptionChainSchema = z.object({
+  options: z.array(z.object({
+    expiryDate: z.string(),
+    description: z.string(),
+    listingExchange: ListingExchangeSchema,
+    optionExerciseType: OptionExerciseTypeSchema,
+    chainPerRoot: z.array(z.object({
+      root: z.string(),
+      multiplier: z.number().int(),
+      chainPerStrikePrice: z.array(z.object({
+        strikePrice: z.number(),
+        callSymbolId: z.number().int(),
+        putSymbolId: z.number().int()
+      }))
+    }))
+  }))
+});

--- a/src/types/symbols.ts
+++ b/src/types/symbols.ts
@@ -88,14 +88,7 @@ export const SymbolDetailSchema = z.object({
   optionType: OptionTypeSchema.nullable(),
   optionDurationType: OptionDurationTypeSchema.nullable(),
   optionRoot: z.string(),
-  optionContractDeliverables: z.object({
-    underlyings: z.array(z.object({
-      multiplier: z.number().int(),
-      underlyingSymbol: z.string(),
-      underlyingSymbolId: z.number().int()
-    })),
-    cashInLieu: z.number()
-  }),
+  optionContractDeliverables: OptionDeliverablesSchema,
   optionExerciseType: OptionExerciseTypeSchema.nullable(),
   listingExchange: ListingExchangeSchema,
   description: z.string(),


### PR DESCRIPTION
## Summary
- add scaffold script for Questrade type modules
- implement enums, account models, order models, market models, symbol models
- add API response shapes
- export new types via main index

## Testing
- `scripts/verify-all.sh` *(fails: markdownlint not installed)*
- `pnpm exec jest --runInBand` *(fails: command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d2c670a88331a219c7e450e631fb