### PR TITLE
Add Questrade API type schemas

### DIFF
--- a/memory-bank/activeContext.log.md
+++ b/memory-bank/activeContext.log.md
@@ -8,3 +8,4 @@
 - [2025-06-13T21:22:19Z] Removed pnpm-lock.yaml and added rule to avoid lock files; updated AGENTS.md with no-lock-files preference and activeContext with decision note.
 - [2025-06-13T22:45:12Z] Implemented rate limiter hourly buckets and 429 handling in TokenBucketLimiter and RestClient. Updated markdown check script. Verification failing due to existing lint errors.
 - [2025-06-16T04:31:11Z] Consolidated duplicate error handling into src/errors and updated imports.
+- [2025-06-21T15:45:46Z] Added initial Questrade API types and Zod schemas.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -28,6 +28,7 @@ Finishing Questrade SDK core features. Implemented hourly rate-limit buckets wit
   updated documentation for markdownlint compliance.
 - **Rate Limit Patch**: Added hourly token buckets and 429 handling logic in SDK core.
 - **Error Module Consolidation**: Merged duplicate `src/error/` and `src/errors/` directories into a single `src/errors/` module and updated imports.
+- **API Types Added**: Introduced initial Questrade API type definitions and Zod schemas under `src/api/`.
 
 ## Next Steps
 

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -106,9 +106,8 @@ This file tracks all project dependencies, their relationships, and integration 
 - **Shell Scripts**: Automation and setup in `scripts/`
 
 - **Web Framework**: Next.js application in `web/` (when applicable)
-
 - **Prisma ORM**: Database schema and client under `web/prisma/`
-
+- **Zod Validation Library**: Runtime data validation for TypeScript types
 - **PostgreSQL Database**: Service defined in `docker-compose.yml`
 
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This file tracks what works, what remains to be built, current status, and known
 - Next.js app scaffolded with Prisma integration
 - SDK Rate Limiter with hourly buckets and 429 back-off logic
 - Consolidated error handling into `src/errors/` directory
+- Initial Questrade API types and schemas created under `src/api/`
 
 <!-- ai:section:whats-left -->
 ## What's Left

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     ],
     "excludeInternal": true,
     "gitRevision": "main"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
   }
 }

--- a/src/api/accounts.ts
+++ b/src/api/accounts.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+import {
+  AccountType, AccountTypeSchema,
+  AccountStatus, AccountStatusSchema,
+  ClientAccountType, ClientAccountTypeSchema,
+  Currency, CurrencySchema
+} from './commonTypes';
+
+/** Basic account information */
+export interface Account {
+  number: string;
+  type: AccountType;
+  status: AccountStatus;
+  isPrimary: boolean;
+  isBilling: boolean;
+  clientAccountType: ClientAccountType;
+}
+export const AccountSchema = z.object({
+  number: z.string(),
+  type: AccountTypeSchema,
+  status: AccountStatusSchema,
+  isPrimary: z.boolean(),
+  isBilling: z.boolean(),
+  clientAccountType: ClientAccountTypeSchema
+});
+
+/** Per-currency balance details */
+export interface Balance {
+  currency: Currency;
+  cash: number;
+  marketValue: number;
+  totalEquity: number;
+  buyingPower: number;
+  maintenanceExcess: number;
+  isRealTime: boolean;
+}
+export const BalanceSchema = z.object({
+  currency: CurrencySchema,
+  cash: z.number(),
+  marketValue: z.number(),
+  totalEquity: z.number(),
+  buyingPower: z.number(),
+  maintenanceExcess: z.number(),
+  isRealTime: z.boolean()
+});
+
+/** Account positions */
+export interface Position {
+  symbol: string;
+  symbolId: number;
+  openQuantity: number;
+  closedQuantity: number;
+  currentMarketValue: number;
+  currentPrice: number;
+  averageEntryPrice: number;
+  closedPnl: number;
+  openPnl: number;
+  totalCost: number;
+  isRealTime: boolean;
+  isUnderReorg: boolean;
+}
+export const PositionSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  openQuantity: z.number(),
+  closedQuantity: z.number(),
+  currentMarketValue: z.number(),
+  currentPrice: z.number(),
+  averageEntryPrice: z.number(),
+  closedPnl: z.number(),
+  openPnl: z.number(),
+  totalCost: z.number(),
+  isRealTime: z.boolean(),
+  isUnderReorg: z.boolean()
+});
+
+export interface Execution {
+  symbol: string;
+  symbolId: number;
+  quantity: number;
+  side: 'Buy' | 'Sell';
+  price: number;
+  id: number;
+  orderId: number;
+  orderChainId: number;
+  exchangeExecId: string;
+  timestamp: string;
+  notes: string;
+  venue: string;
+  totalCost: number;
+  orderPlacementCommission: number;
+  commission: number;
+  executionFee: number;
+  secFee: number;
+  canadianExecutionFee: number;
+  parentId: number;
+}
+export const ExecutionSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  quantity: z.number().int(),
+  side: z.enum(['Buy','Sell']),
+  price: z.number(),
+  id: z.number().int(),
+  orderId: z.number().int(),
+  orderChainId: z.number().int(),
+  exchangeExecId: z.string(),
+  timestamp: z.string(),
+  notes: z.string(),
+  venue: z.string(),
+  totalCost: z.number(),
+  orderPlacementCommission: z.number(),
+  commission: z.number(),
+  executionFee: z.number(),
+  secFee: z.number(),
+  canadianExecutionFee: z.number().int(),
+  parentId: z.number().int()
+});
+
+export interface AccountActivity {
+  tradeDate: string;
+  transactionDate: string;
+  settlementDate: string;
+  action: string;
+  symbol: string;
+  symbolId: number;
+  description: string;
+  currency: Currency;
+  quantity: number;
+  price: number;
+  grossAmount: number;
+  commission: number;
+  netAmount: number;
+  type: string;
+}
+export const AccountActivitySchema = z.object({
+  tradeDate: z.string(),
+  transactionDate: z.string(),
+  settlementDate: z.string(),
+  action: z.string(),
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  description: z.string(),
+  currency: CurrencySchema,
+  quantity: z.number(),
+  price: z.number(),
+  grossAmount: z.number(),
+  commission: z.number(),
+  netAmount: z.number(),
+  type: z.string()
+});
+

--- a/src/api/commonTypes.ts
+++ b/src/api/commonTypes.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+
+/** Allowed currency codes */
+export type Currency = 'USD' | 'CAD';
+export const CurrencySchema = z.enum(['USD', 'CAD']);
+
+/** Listing exchange codes */
+export type ListingExchange =
+  | 'TSX' | 'TSXV' | 'CNSX' | 'MX'
+  | 'NASDAQ' | 'NYSE' | 'NYSEAM' | 'ARCA'
+  | 'OPRA' | 'PinkSheets' | 'OTCBB';
+export const ListingExchangeSchema = z.enum([
+  'TSX','TSXV','CNSX','MX','NASDAQ','NYSE','NYSEAM','ARCA','OPRA','PinkSheets','OTCBB'
+]);
+
+/** Registration account types */
+export type AccountType =
+  | 'Cash' | 'Margin'
+  | 'TFSA' | 'RRSP' | 'FHSA' | 'SRRSP' | 'LRRSP'
+  | 'LIRA' | 'LIF' | 'RIF' | 'SRIF' | 'LRIF'
+  | 'RRIF' | 'PRIF'
+  | 'RESP' | 'FRESP';
+export const AccountTypeSchema = z.enum([
+  'Cash','Margin','TFSA','RRSP','FHSA','SRRSP','LRRSP','LIRA','LIF','RIF','SRIF','LRIF','RRIF','PRIF','RESP','FRESP'
+]);
+
+/** Client account ownership categories */
+export type ClientAccountType =
+  | 'Individual' | 'Joint' | 'Informal Trust'
+  | 'Corporation' | 'Formal Trust' | 'Partnership'
+  | 'Sole Proprietorship' | 'Family'
+  | 'Joint and Informal Trust' | 'Institution';
+export const ClientAccountTypeSchema = z.enum([
+  'Individual','Joint','Informal Trust','Corporation','Formal Trust','Partnership','Sole Proprietorship','Family','Joint and Informal Trust','Institution'
+]);
+
+/** Possible status values for an account */
+export type AccountStatus =
+  | 'Active'
+  | 'Suspended (Closed)'
+  | 'Suspended (View Only)'
+  | 'Liquidate Only'
+  | 'Closed';
+export const AccountStatusSchema = z.enum([
+  'Active','Suspended (Closed)','Suspended (View Only)','Liquidate Only','Closed'
+]);
+
+export type TickType = 'Up' | 'Down' | 'Equal';
+export const TickTypeSchema = z.enum(['Up','Down','Equal']);
+
+export type OptionType = 'Call' | 'Put';
+export const OptionTypeSchema = z.enum(['Call','Put']);
+
+export type OptionDurationType = 'Weekly' | 'Monthly' | 'Quarterly' | 'LEAP';
+export const OptionDurationTypeSchema = z.enum(['Weekly','Monthly','Quarterly','LEAP']);
+
+export type OptionExerciseType = 'American' | 'European';
+export const OptionExerciseTypeSchema = z.enum(['American','European']);
+
+export type SecurityType = 'Stock' | 'Option' | 'Bond' | 'Right' | 'Gold' | 'MutualFund' | 'Index';
+export const SecurityTypeSchema = z.enum(['Stock','Option','Bond','Right','Gold','MutualFund','Index']);
+
+export type OrderStateFilter = 'All' | 'Open' | 'Closed';
+export const OrderStateFilterSchema = z.enum(['All','Open','Closed']);
+
+export type OrderAction = 'Buy' | 'Sell';
+export const OrderActionSchema = z.enum(['Buy','Sell']);
+
+export type OrderSide = 'Buy' | 'Sell' | 'Short' | 'Cov' | 'BTO' | 'STC' | 'STO' | 'BTC';
+export const OrderSideSchema = z.enum(['Buy','Sell','Short','Cov','BTO','STC','STO','BTC']);
+
+export type OrderType =
+  | 'Market' | 'Limit' | 'Stop' | 'StopLimit'
+  | 'TrailStopInPercentage' | 'TrailStopInDollar'
+  | 'TrailStopLimitInPercentage' | 'TrailStopLimitInDollar'
+  | 'LimitOnOpen' | 'LimitOnClose';
+export const OrderTypeSchema = z.enum([
+  'Market','Limit','Stop','StopLimit','TrailStopInPercentage','TrailStopInDollar','TrailStopLimitInPercentage','TrailStopLimitInDollar','LimitOnOpen','LimitOnClose'
+]);
+
+export type TimeInForce =
+  | 'Day' | 'GoodTillCanceled' | 'GoodTillExtendedDay'
+  | 'GoodTillDate' | 'ImmediateOrCancel' | 'FillOrKill';
+export const TimeInForceSchema = z.enum([
+  'Day','GoodTillCanceled','GoodTillExtendedDay','GoodTillDate','ImmediateOrCancel','FillOrKill'
+]);
+
+export type OrderState =
+  | 'Failed' | 'Pending' | 'Accepted' | 'Rejected'
+  | 'CancelPending' | 'Canceled' | 'PartialCanceled'
+  | 'Partial' | 'Executed' | 'ReplacePending' | 'Replaced'
+  | 'Stopped' | 'Suspended' | 'Expired' | 'Queued'
+  | 'Triggered' | 'Activated' | 'PendingRiskReview'
+  | 'ContingentOrder';
+export const OrderStateSchema = z.enum([
+  'Failed','Pending','Accepted','Rejected','CancelPending','Canceled','PartialCanceled','Partial','Executed','ReplacePending','Replaced','Stopped','Suspended','Expired','Queued','Triggered','Activated','PendingRiskReview','ContingentOrder'
+]);
+
+export type CandleInterval =
+  | 'OneMinute' | 'TwoMinutes' | 'ThreeMinutes' | 'FourMinutes' | 'FiveMinutes'
+  | 'TenMinutes' | 'FifteenMinutes' | 'TwentyMinutes'
+  | 'HalfHour' | 'OneHour' | 'TwoHours' | 'FourHours'
+  | 'OneDay' | 'OneWeek' | 'OneMonth' | 'OneYear';
+export const CandleIntervalSchema = z.enum([
+  'OneMinute','TwoMinutes','ThreeMinutes','FourMinutes','FiveMinutes','TenMinutes','FifteenMinutes','TwentyMinutes','HalfHour','OneHour','TwoHours','FourHours','OneDay','OneWeek','OneMonth','OneYear'
+]);
+
+export type OrderClass = 'Primary' | 'Limit' | 'StopLoss';
+export const OrderClassSchema = z.enum(['Primary','Limit','StopLoss']);
+
+export type StrategyType =
+  | 'CoveredCall' | 'MarriedPuts'
+  | 'VerticalCallSpread' | 'VerticalPutSpread'
+  | 'CalendarCallSpread' | 'CalendarPutSpread'
+  | 'DiagonalCallSpread' | 'DiagonalPutSpread'
+  | 'Collar' | 'Straddle' | 'Strangle'
+  | 'ButterflyCall' | 'ButterflyPut'
+  | 'IronButterfly' | 'CondorCall'
+  | 'Custom';
+export const StrategyTypeSchema = z.enum([
+  'CoveredCall','MarriedPuts','VerticalCallSpread','VerticalPutSpread','CalendarCallSpread','CalendarPutSpread','DiagonalCallSpread','DiagonalPutSpread','Collar','Straddle','Strangle','ButterflyCall','ButterflyPut','IronButterfly','CondorCall','Custom'
+]);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from './commonTypes';
+export * from './accounts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './client/QuestradeClient';
 export * from './auth/interfaces';
 export * from './auth/manager';
 export * from './http/restClient';
+export * from './api';


### PR DESCRIPTION
## Summary
- introduce enumerations and schemas for Questrade API in `src/api`
- create account related models with Zod validation
- export API modules via `src/index.ts`
- track `zod` as a dependency
- log and document progress in memory bank

## Testing
- `scripts/verify-all.sh` *(fails: markdownlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d2c670a88331a219c7e450e631fb