### PR TITLE
Add Questrade enums and account schemas

### DIFF
--- a/memory-bank/activeContext.log.md
+++ b/memory-bank/activeContext.log.md
@@ -8,3 +8,4 @@
 - [2025-06-13T21:22:19Z] Removed pnpm-lock.yaml and added rule to avoid lock files; updated AGENTS.md with no-lock-files preference and activeContext with decision note.
 - [2025-06-13T22:45:12Z] Implemented rate limiter hourly buckets and 429 handling in TokenBucketLimiter and RestClient. Updated markdown check script. Verification failing due to existing lint errors.
 - [2025-06-16T04:31:11Z] Consolidated duplicate error handling into src/errors and updated imports.
+- [2025-06-21T15:47:38Z] Added Questrade enum and account schemas with Zod for typed API responses.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,7 +17,7 @@ This file tracks the current work focus, recent changes, next steps, and active 
 
 ## Current Work Focus
 
-Finishing Questrade SDK core features. Implemented hourly rate-limit buckets with 429 back-off logic while continuing web integration work.
+Finishing Questrade SDK core features. Implemented hourly rate-limit buckets with 429 back-off logic while continuing web integration work. Currently implementing typed schemas for Questrade API.
 
 ## Recent Changes
 
@@ -28,6 +28,7 @@ Finishing Questrade SDK core features. Implemented hourly rate-limit buckets wit
   updated documentation for markdownlint compliance.
 - **Rate Limit Patch**: Added hourly token buckets and 429 handling logic in SDK core.
 - **Error Module Consolidation**: Merged duplicate `src/error/` and `src/errors/` directories into a single `src/errors/` module and updated imports.
+- **Questrade Types**: Added enums and account schemas with Zod for API typing.
 
 ## Next Steps
 
@@ -45,6 +46,7 @@ Finishing Questrade SDK core features. Implemented hourly rate-limit buckets wit
 ### Expansion
 - Integrate Python API routes with Next.js front end
 - Extend authentication to token-based system
+- Expand Questrade type coverage for markets and symbols
 
 ## Active Decisions
 

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -98,6 +98,7 @@ This file tracks all project dependencies, their relationships, and integration 
 
 
 - **TypeScript Runtime**: Core language support in `src/`
+- **Zod**: Runtime schema validation for API types
 
 - **Python Environment**: Conditional module support in `python/`
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This file tracks what works, what remains to be built, current status, and known
 - Next.js app scaffolded with Prisma integration
 - SDK Rate Limiter with hourly buckets and 429 back-off logic
 - Consolidated error handling into `src/errors/` directory
+- Questrade enums and account schemas implemented with Zod
 
 <!-- ai:section:whats-left -->
 ## What's Left

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     ],
     "excludeInternal": true,
     "gitRevision": "main"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './client/QuestradeClient';
 export * from './auth/interfaces';
 export * from './auth/manager';
 export * from './http/restClient';
+export * from './types';

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod'
+import {
+  AccountTypeSchema,
+  AccountStatusSchema,
+  ClientAccountTypeSchema,
+  CurrencySchema,
+  OrderActionSchema
+} from './enums'
+
+/** Basic account information. */
+export interface Account {
+  number: string
+  type: z.infer<typeof AccountTypeSchema>
+  status: z.infer<typeof AccountStatusSchema>
+  isPrimary: boolean
+  isBilling: boolean
+  clientAccountType: z.infer<typeof ClientAccountTypeSchema>
+}
+
+export const AccountSchema = z.object({
+  number: z.string(),
+  type: AccountTypeSchema,
+  status: AccountStatusSchema,
+  isPrimary: z.boolean(),
+  isBilling: z.boolean(),
+  clientAccountType: ClientAccountTypeSchema
+})
+
+/** Per-currency balance info. */
+export interface Balance {
+  currency: z.infer<typeof CurrencySchema>
+  cash: number
+  marketValue: number
+  totalEquity: number
+  buyingPower: number
+  maintenanceExcess: number
+  isRealTime: boolean
+}
+
+export const BalanceSchema = z.object({
+  currency: CurrencySchema,
+  cash: z.number(),
+  marketValue: z.number(),
+  totalEquity: z.number(),
+  buyingPower: z.number(),
+  maintenanceExcess: z.number(),
+  isRealTime: z.boolean()
+})
+
+/** A position held in an account. */
+export interface Position {
+  symbol: string
+  symbolId: number
+  openQuantity: number
+  closedQuantity: number
+  currentMarketValue: number
+  currentPrice: number
+  averageEntryPrice: number
+  closedPnl: number
+  openPnl: number
+  totalCost: number
+  isRealTime: boolean
+  isUnderReorg: boolean
+}
+
+export const PositionSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  openQuantity: z.number(),
+  closedQuantity: z.number(),
+  currentMarketValue: z.number(),
+  currentPrice: z.number(),
+  averageEntryPrice: z.number(),
+  closedPnl: z.number(),
+  openPnl: z.number(),
+  totalCost: z.number(),
+  isRealTime: z.boolean(),
+  isUnderReorg: z.boolean()
+})
+
+/** An execution fill. */
+export interface Execution {
+  symbol: string
+  symbolId: number
+  quantity: number
+  side: z.infer<typeof OrderActionSchema>
+  price: number
+  id: number
+  orderId: number
+  orderChainId: number
+  exchangeExecId: string
+  timestamp: string
+  notes: string
+  venue: string
+  totalCost: number
+  orderPlacementCommission: number
+  commission: number
+  executionFee: number
+  secFee: number
+  canadianExecutionFee: number
+  parentId: number
+}
+
+export const ExecutionSchema = z.object({
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  quantity: z.number().int(),
+  side: OrderActionSchema,
+  price: z.number(),
+  id: z.number().int(),
+  orderId: z.number().int(),
+  orderChainId: z.number().int(),
+  exchangeExecId: z.string(),
+  timestamp: z.string(),
+  notes: z.string(),
+  venue: z.string(),
+  totalCost: z.number(),
+  orderPlacementCommission: z.number(),
+  commission: z.number(),
+  executionFee: z.number(),
+  secFee: z.number(),
+  canadianExecutionFee: z.number().int(),
+  parentId: z.number().int()
+})
+
+/** Account activity entry. */
+export interface AccountActivity {
+  tradeDate: string
+  transactionDate: string
+  settlementDate: string
+  action: string
+  symbol: string
+  symbolId: number
+  description: string
+  currency: z.infer<typeof CurrencySchema>
+  quantity: number
+  price: number
+  grossAmount: number
+  commission: number
+  netAmount: number
+  type: string
+}
+
+export const AccountActivitySchema = z.object({
+  tradeDate: z.string(),
+  transactionDate: z.string(),
+  settlementDate: z.string(),
+  action: z.string(),
+  symbol: z.string(),
+  symbolId: z.number().int(),
+  description: z.string(),
+  currency: CurrencySchema,
+  quantity: z.number(),
+  price: z.number(),
+  grossAmount: z.number(),
+  commission: z.number(),
+  netAmount: z.number(),
+  type: z.string()
+})
+
+/** Response shapes */
+export interface AccountsResponse {
+  accounts: Account[]
+  userId: number
+}
+export const AccountsResponseSchema = z.object({
+  accounts: z.array(AccountSchema),
+  userId: z.number().int()
+})
+
+export interface AccountBalancesResponse {
+  perCurrencyBalances: Balance[]
+  combinedBalances: Balance[]
+  sodPerCurrencyBalances: Balance[]
+  sodCombinedBalances: Balance[]
+}
+export const AccountBalancesResponseSchema = z.object({
+  perCurrencyBalances: z.array(BalanceSchema),
+  combinedBalances: z.array(BalanceSchema),
+  sodPerCurrencyBalances: z.array(BalanceSchema),
+  sodCombinedBalances: z.array(BalanceSchema)
+})
+
+export interface PositionsResponse {
+  positions: Position[]
+}
+export const PositionsResponseSchema = z.object({
+  positions: z.array(PositionSchema)
+})
+
+export interface ExecutionsResponse {
+  executions: Execution[]
+}
+export const ExecutionsResponseSchema = z.object({
+  executions: z.array(ExecutionSchema)
+})
+
+export interface ActivitiesResponse {
+  activities: AccountActivity[]
+}
+export const ActivitiesResponseSchema = z.object({
+  activities: z.array(AccountActivitySchema)
+})

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod'
+
+/** Supported currency codes. */
+export type Currency = 'USD' | 'CAD'
+export const CurrencySchema = z.enum(['USD', 'CAD'])
+
+/** Listing exchanges for securities. */
+export type ListingExchange =
+  | 'TSX' | 'TSXV' | 'CNSX' | 'MX'
+  | 'NASDAQ' | 'NYSE' | 'NYSEAM' | 'ARCA'
+  | 'OPRA' | 'PinkSheets' | 'OTCBB'
+export const ListingExchangeSchema = z.enum([
+  'TSX', 'TSXV', 'CNSX', 'MX',
+  'NASDAQ', 'NYSE', 'NYSEAM', 'ARCA',
+  'OPRA', 'PinkSheets', 'OTCBB'
+])
+
+/** Account registration categories. */
+export type AccountType =
+  | 'Cash' | 'Margin'
+  | 'TFSA' | 'RRSP' | 'FHSA' | 'SRRSP' | 'LRRSP'
+  | 'LIRA' | 'LIF' | 'RIF' | 'SRIF' | 'LRIF'
+  | 'RRIF' | 'PRIF'
+  | 'RESP' | 'FRESP'
+export const AccountTypeSchema = z.enum([
+  'Cash', 'Margin', 'TFSA', 'RRSP', 'FHSA', 'SRRSP', 'LRRSP',
+  'LIRA', 'LIF', 'RIF', 'SRIF', 'LRIF', 'RRIF', 'PRIF', 'RESP', 'FRESP'
+])
+
+/** Client ownership categories. */
+export type ClientAccountType =
+  | 'Individual' | 'Joint' | 'Informal Trust'
+  | 'Corporation' | 'Formal Trust' | 'Partnership'
+  | 'Sole Proprietorship' | 'Family'
+  | 'Joint and Informal Trust' | 'Institution'
+export const ClientAccountTypeSchema = z.enum([
+  'Individual', 'Joint', 'Informal Trust', 'Corporation', 'Formal Trust',
+  'Partnership', 'Sole Proprietorship', 'Family', 'Joint and Informal Trust',
+  'Institution'
+])
+
+/** Possible user account statuses. */
+export type AccountStatus =
+  | 'Active'
+  | 'Suspended (Closed)'
+  | 'Suspended (View Only)'
+  | 'Liquidate Only'
+  | 'Closed'
+export const AccountStatusSchema = z.enum([
+  'Active', 'Suspended (Closed)', 'Suspended (View Only)', 'Liquidate Only',
+  'Closed'
+])
+
+/** Price change directions. */
+export type TickType = 'Up' | 'Down' | 'Equal'
+export const TickTypeSchema = z.enum(['Up', 'Down', 'Equal'])
+
+/** Option contract types. */
+export type OptionType = 'Call' | 'Put'
+export const OptionTypeSchema = z.enum(['Call', 'Put'])
+
+/** Option expiration cycles. */
+export type OptionDurationType = 'Weekly' | 'Monthly' | 'Quarterly' | 'LEAP'
+export const OptionDurationTypeSchema = z.enum([
+  'Weekly', 'Monthly', 'Quarterly', 'LEAP'
+])
+
+/** Option exercise styles. */
+export type OptionExerciseType = 'American' | 'European'
+export const OptionExerciseTypeSchema = z.enum(['American', 'European'])
+
+/** Security asset classes. */
+export type SecurityType =
+  'Stock' | 'Option' | 'Bond' | 'Right' | 'Gold' | 'MutualFund' | 'Index'
+export const SecurityTypeSchema = z.enum([
+  'Stock', 'Option', 'Bond', 'Right', 'Gold', 'MutualFund', 'Index'
+])
+
+/** Order state filter for order queries. */
+export type OrderStateFilter = 'All' | 'Open' | 'Closed'
+export const OrderStateFilterSchema = z.enum(['All', 'Open', 'Closed'])
+
+/** Basic buy/sell actions. */
+export type OrderAction = 'Buy' | 'Sell'
+export const OrderActionSchema = z.enum(['Buy', 'Sell'])
+
+/** Extended order sides including short/cover. */
+export type OrderSide =
+  | 'Buy' | 'Sell' | 'Short' | 'Cov'
+  | 'BTO' | 'STC' | 'STO' | 'BTC'
+export const OrderSideSchema = z.enum([
+  'Buy', 'Sell', 'Short', 'Cov', 'BTO', 'STC', 'STO', 'BTC'
+])
+
+/** Order pricing instructions. */
+export type OrderType =
+  | 'Market' | 'Limit' | 'Stop' | 'StopLimit'
+  | 'TrailStopInPercentage' | 'TrailStopInDollar'
+  | 'TrailStopLimitInPercentage' | 'TrailStopLimitInDollar'
+  | 'LimitOnOpen' | 'LimitOnClose'
+export const OrderTypeSchema = z.enum([
+  'Market', 'Limit', 'Stop', 'StopLimit',
+  'TrailStopInPercentage', 'TrailStopInDollar',
+  'TrailStopLimitInPercentage', 'TrailStopLimitInDollar',
+  'LimitOnOpen', 'LimitOnClose'
+])
+
+/** Time-In-Force instructions. */
+export type TimeInForce =
+  | 'Day' | 'GoodTillCanceled' | 'GoodTillExtendedDay'
+  | 'GoodTillDate' | 'ImmediateOrCancel' | 'FillOrKill'
+export const TimeInForceSchema = z.enum([
+  'Day', 'GoodTillCanceled', 'GoodTillExtendedDay',
+  'GoodTillDate', 'ImmediateOrCancel', 'FillOrKill'
+])
+
+/** Order life cycle states. */
+export type OrderState =
+  | 'Failed' | 'Pending' | 'Accepted' | 'Rejected'
+  | 'CancelPending' | 'Canceled' | 'PartialCanceled'
+  | 'Partial' | 'Executed' | 'ReplacePending' | 'Replaced'
+  | 'Stopped' | 'Suspended' | 'Expired' | 'Queued'
+  | 'Triggered' | 'Activated' | 'PendingRiskReview'
+  | 'ContingentOrder'
+export const OrderStateSchema = z.enum([
+  'Failed', 'Pending', 'Accepted', 'Rejected',
+  'CancelPending', 'Canceled', 'PartialCanceled',
+  'Partial', 'Executed', 'ReplacePending', 'Replaced',
+  'Stopped', 'Suspended', 'Expired', 'Queued',
+  'Triggered', 'Activated', 'PendingRiskReview', 'ContingentOrder'
+])
+
+/** Candlestick intervals for historical data. */
+export type CandleInterval =
+  | 'OneMinute' | 'TwoMinutes' | 'ThreeMinutes' | 'FourMinutes' | 'FiveMinutes'
+  | 'TenMinutes' | 'FifteenMinutes' | 'TwentyMinutes'
+  | 'HalfHour' | 'OneHour' | 'TwoHours' | 'FourHours'
+  | 'OneDay' | 'OneWeek' | 'OneMonth' | 'OneYear'
+export const CandleIntervalSchema = z.enum([
+  'OneMinute', 'TwoMinutes', 'ThreeMinutes', 'FourMinutes', 'FiveMinutes',
+  'TenMinutes', 'FifteenMinutes', 'TwentyMinutes',
+  'HalfHour', 'OneHour', 'TwoHours', 'FourHours',
+  'OneDay', 'OneWeek', 'OneMonth', 'OneYear'
+])
+
+/** Order classes within bracket orders. */
+export type OrderClass = 'Primary' | 'Limit' | 'StopLoss'
+export const OrderClassSchema = z.enum(['Primary', 'Limit', 'StopLoss'])
+
+/** Multi-leg strategy types for option orders. */
+export type StrategyType =
+  | 'CoveredCall' | 'MarriedPuts'
+  | 'VerticalCallSpread' | 'VerticalPutSpread'
+  | 'CalendarCallSpread' | 'CalendarPutSpread'
+  | 'DiagonalCallSpread' | 'DiagonalPutSpread'
+  | 'Collar' | 'Straddle' | 'Strangle'
+  | 'ButterflyCall' | 'ButterflyPut'
+  | 'IronButterfly' | 'CondorCall'
+  | 'Custom'
+export const StrategyTypeSchema = z.enum([
+  'CoveredCall', 'MarriedPuts', 'VerticalCallSpread', 'VerticalPutSpread',
+  'CalendarCallSpread', 'CalendarPutSpread', 'DiagonalCallSpread',
+  'DiagonalPutSpread', 'Collar', 'Straddle', 'Strangle', 'ButterflyCall',
+  'ButterflyPut', 'IronButterfly', 'CondorCall', 'Custom'
+])

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './enums'
+export * from './accounts'


### PR DESCRIPTION
## Summary
- implement Questrade enums as union types with zod schemas
- add account related interfaces and response shapes with zod validation
- export new types from SDK entrypoint
- document new dependency on Zod in memory bank
- record progress and context updates

## Testing
- `scripts/verify-all.sh` *(fails: markdownlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d2c670a88331a219c7e450e631fb