### PR TITLE
Add tests for accounts schemas

### DIFF
--- a/tests/accountActivitySchema.test.ts
+++ b/tests/accountActivitySchema.test.ts
@@ -1,0 +1,30 @@
+import { AccountActivitySchema } from '../src/types/accounts';
+
+describe('AccountActivitySchema', () => {
+  it('accepts a valid AccountActivity', () => {
+    const input = {
+      tradeDate: '2024-01-01',
+      transactionDate: '2024-01-02',
+      settlementDate: '2024-01-03',
+      action: 'Buy',
+      symbol: 'AAPL',
+      symbolId: 1,
+      description: 'desc',
+      currency: 'USD',
+      quantity: 1,
+      price: 100,
+      grossAmount: 100,
+      commission: 1,
+      netAmount: 99,
+      type: 'Order'
+    };
+    const result = AccountActivitySchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const { success, error } = AccountActivitySchema.safeParse({ tradeDate: '2024-01-01' });
+    expect(success).toBe(false);
+    expect(error?.issues.some(i => i.path.includes('transactionDate'))).toBe(true);
+  });
+});

--- a/tests/accountSchema.test.ts
+++ b/tests/accountSchema.test.ts
@@ -1,0 +1,22 @@
+import { AccountSchema } from '../src/types/accounts';
+
+describe('AccountSchema', () => {
+  it('accepts a valid Account', () => {
+    const input = {
+      number: 'ABC12345',
+      type: 'Cash',
+      status: 'Active',
+      isPrimary: true,
+      isBilling: false,
+      clientAccountType: 'Individual'
+    };
+    const result = AccountSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const { success, error } = AccountSchema.safeParse({ number: 'ABC12345' });
+    expect(success).toBe(false);
+    expect(error?.issues.some(i => i.path.includes('type'))).toBe(true);
+  });
+});

--- a/tests/balanceSchema.test.ts
+++ b/tests/balanceSchema.test.ts
@@ -1,0 +1,23 @@
+import { BalanceSchema } from '../src/types/accounts';
+
+describe('BalanceSchema', () => {
+  it('accepts a valid Balance', () => {
+    const input = {
+      currency: 'USD',
+      cash: 100,
+      marketValue: 150,
+      totalEquity: 250,
+      buyingPower: 200,
+      maintenanceExcess: 50,
+      isRealTime: true
+    };
+    const result = BalanceSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const { success, error } = BalanceSchema.safeParse({ currency: 'USD' });
+    expect(success).toBe(false);
+    expect(error?.issues.some(i => i.path.includes('cash'))).toBe(true);
+  });
+});

--- a/tests/executionSchema.test.ts
+++ b/tests/executionSchema.test.ts
@@ -1,0 +1,37 @@
+import { ExecutionSchema } from '../src/types/accounts';
+
+const now = new Date().toISOString();
+
+describe('ExecutionSchema', () => {
+  it('accepts a valid Execution', () => {
+    const input = {
+      symbol: 'AAPL',
+      symbolId: 1,
+      quantity: 1,
+      side: 'Buy',
+      price: 100,
+      id: 123,
+      orderId: 456,
+      orderChainId: 789,
+      exchangeExecId: 'ex',
+      timestamp: now,
+      notes: 'note',
+      venue: 'NYSE',
+      totalCost: 100,
+      orderPlacementCommission: 1,
+      commission: 1,
+      executionFee: 1,
+      secFee: 1,
+      canadianExecutionFee: 1,
+      parentId: 0
+    };
+    const result = ExecutionSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const { success, error } = ExecutionSchema.safeParse({ symbol: 'AAPL' });
+    expect(success).toBe(false);
+    expect(error?.issues.some(i => i.path.includes('symbolId'))).toBe(true);
+  });
+});

--- a/tests/positionSchema.test.ts
+++ b/tests/positionSchema.test.ts
@@ -1,0 +1,28 @@
+import { PositionSchema } from '../src/types/accounts';
+
+describe('PositionSchema', () => {
+  it('accepts a valid Position', () => {
+    const input = {
+      symbol: 'AAPL',
+      symbolId: 1,
+      openQuantity: 10,
+      closedQuantity: 0,
+      currentMarketValue: 1000,
+      currentPrice: 100,
+      averageEntryPrice: 90,
+      closedPnl: 0,
+      openPnl: 100,
+      totalCost: 900,
+      isRealTime: true,
+      isUnderReorg: false
+    };
+    const result = PositionSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const { success, error } = PositionSchema.safeParse({ symbol: 'AAPL' });
+    expect(success).toBe(false);
+    expect(error?.issues.some(i => i.path.includes('symbolId'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- test BalanceSchema validation
- test PositionSchema validation
- test ExecutionSchema validation
- test AccountActivitySchema validation

## Testing
- `pnpm test` *(fails: jest not found)*
- `npx markdownlint --strict "**/*.md"` *(fails: E403 Forbidden)*
- `scripts/verify-all.sh` *(fails: markdownlint command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857abe050248331afb225b871463c73