### PR TITLE
Initialize TypeScript agent framework

### DIFF
--- a/agent-framework/README.md
+++ b/agent-framework/README.md
@@ -1,0 +1,5 @@
+# Agent Framework
+
+This folder contains a TypeScript-based multi-agent retrieval system. Run `scripts/setup_agent_framework.sh` to regenerate the initial project structure.
+
+Use `pnpm` to build and test once dependencies are installed.

--- a/agent-framework/package.json
+++ b/agent-framework/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-framework",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.21.0",
+    "p-limit": "^5.0.0",
+    "pinecone-client": "^3.2.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/agent-framework/src/cli/index.ts
+++ b/agent-framework/src/cli/index.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { loadGraph } from '../loader.js';
+
+const graphFile = process.argv[2] || 'examples/hierarchical.json';
+
+async function main() {
+  const graph = await loadGraph(new URL(graphFile, import.meta.url).pathname);
+  process.stdin.on('data', async (d) => {
+    const res = await graph.act(d.toString().trim(), { memory: new (await import('../core/InMemoryMemory.js')).InMemoryMemory(), tools: { vector: new (await import('../core/InMemoryVectorStore.js')).InMemoryVectorStore() } });
+    console.log(res.content);
+  });
+}
+main();

--- a/agent-framework/src/core/Agent.ts
+++ b/agent-framework/src/core/Agent.ts
@@ -1,0 +1,15 @@
+export interface Observation { content: string; meta?: Record<string, any>; }
+
+export interface AgentContext {
+  memory: Memory;
+  tools: Record<string, Tool>;
+}
+
+export interface Agent {
+  id: string;
+  describe(): string;
+  act(input: string, ctx: AgentContext): Promise<Observation>;
+}
+
+import type { Memory } from './Memory.js';
+import type { Tool } from './Tool.js';

--- a/agent-framework/src/core/InMemoryMemory.ts
+++ b/agent-framework/src/core/InMemoryMemory.ts
@@ -1,0 +1,11 @@
+import type { Memory } from './Memory.js';
+
+export class InMemoryMemory implements Memory {
+  private log: string[] = [];
+  async read(_query: string): Promise<string> {
+    return this.log.join('\n');
+  }
+  async write(entry: string): Promise<void> {
+    this.log.push(entry);
+  }
+}

--- a/agent-framework/src/core/InMemoryVectorStore.ts
+++ b/agent-framework/src/core/InMemoryVectorStore.ts
@@ -1,0 +1,16 @@
+import type { VectorStore } from './VectorStore.js';
+
+export class InMemoryVectorStore implements VectorStore {
+  private store = new Map<string, string>();
+  async upsert(id: string, text: string): Promise<void> {
+    this.store.set(id, text);
+  }
+  async query(text: string, k: number): Promise<string[]> {
+    const results: string[] = [];
+    for (const value of this.store.values()) {
+      if (value.includes(text)) results.push(value);
+      if (results.length >= k) break;
+    }
+    return results;
+  }
+}

--- a/agent-framework/src/core/Memory.ts
+++ b/agent-framework/src/core/Memory.ts
@@ -1,0 +1,4 @@
+export interface Memory {
+  read(query: string): Promise<string>;
+  write(entry: string): Promise<void>;
+}

--- a/agent-framework/src/core/Tool.ts
+++ b/agent-framework/src/core/Tool.ts
@@ -1,0 +1,5 @@
+export interface Tool {
+  name: string;
+  run(args: string): Promise<string>;
+  schema: Record<string, any>;
+}

--- a/agent-framework/src/core/VectorStore.ts
+++ b/agent-framework/src/core/VectorStore.ts
@@ -1,0 +1,4 @@
+export interface VectorStore {
+  upsert(id: string, text: string): Promise<void>;
+  query(text: string, k: number): Promise<string[]>;
+}

--- a/agent-framework/src/examples/agents/CriticAgent.ts
+++ b/agent-framework/src/examples/agents/CriticAgent.ts
@@ -1,0 +1,10 @@
+import type { Agent, AgentContext, Observation } from '../../core/Agent.js';
+
+export class CriticAgent implements Agent {
+  id = 'CriticAgent';
+  describe() { return 'Rates output'; }
+  async act(input: string, _ctx: AgentContext): Promise<Observation> {
+    const score = input.length % 5;
+    return { content: `${input}\nScore:${score}` };
+  }
+}

--- a/agent-framework/src/examples/agents/HumanGate.ts
+++ b/agent-framework/src/examples/agents/HumanGate.ts
@@ -1,0 +1,13 @@
+import type { Agent, AgentContext, Observation } from '../../core/Agent.js';
+import readline from 'node:readline/promises';
+
+export class HumanGate implements Agent {
+  id = 'HumanGate';
+  describe() { return 'Waits for human input'; }
+  async act(_input: string, _ctx: AgentContext): Promise<Observation> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const ans = await rl.question('> ');
+    rl.close();
+    return { content: ans };
+  }
+}

--- a/agent-framework/src/examples/agents/RetrieverAgent.ts
+++ b/agent-framework/src/examples/agents/RetrieverAgent.ts
@@ -1,0 +1,10 @@
+import type { Agent, AgentContext, Observation } from '../../core/Agent.js';
+
+export class RetrieverAgent implements Agent {
+  id = 'RetrieverAgent';
+  describe() { return 'Searches VectorStore then ToolSearch'; }
+  async act(input: string, ctx: AgentContext): Promise<Observation> {
+    const hits = await ctx.tools.vector.query(input, 5);
+    return { content: hits.join('\n') };
+  }
+}

--- a/agent-framework/src/examples/agents/WriterAgent.ts
+++ b/agent-framework/src/examples/agents/WriterAgent.ts
@@ -1,0 +1,9 @@
+import type { Agent, AgentContext, Observation } from '../../core/Agent.js';
+
+export class WriterAgent implements Agent {
+  id = 'WriterAgent';
+  describe() { return 'Uses LLM to draft answer'; }
+  async act(input: string, _ctx: AgentContext): Promise<Observation> {
+    return { content: `Answer: ${input}` };
+  }
+}

--- a/agent-framework/src/examples/hierarchical.json
+++ b/agent-framework/src/examples/hierarchical.json
@@ -1,0 +1,8 @@
+{
+  "type": "hierarchical",
+  "supervisor": { "type": "CriticAgent" },
+  "children": [
+    { "type": "RetrieverAgent" },
+    { "type": "WriterAgent" }
+  ]
+}

--- a/agent-framework/src/examples/loop.json
+++ b/agent-framework/src/examples/loop.json
@@ -1,0 +1,6 @@
+{
+  "type": "loop",
+  "max": 3,
+  "stopWord": "DONE",
+  "child": { "type": "WriterAgent" }
+}

--- a/agent-framework/src/examples/router.json
+++ b/agent-framework/src/examples/router.json
@@ -1,0 +1,8 @@
+{
+  "type": "router",
+  "routes": {
+    "search": { "type": "RetrieverAgent" },
+    "write": { "type": "WriterAgent" },
+    "*": { "type": "CriticAgent" }
+  }
+}

--- a/agent-framework/src/examples/sequential.json
+++ b/agent-framework/src/examples/sequential.json
@@ -1,0 +1,7 @@
+{
+  "type": "sequential",
+  "children": [
+    { "type": "RetrieverAgent" },
+    { "type": "WriterAgent" }
+  ]
+}

--- a/agent-framework/src/loader.ts
+++ b/agent-framework/src/loader.ts
@@ -1,0 +1,35 @@
+import { parallel } from './patterns/parallel.js';
+import { sequential } from './patterns/sequential.js';
+import { router } from './patterns/router.js';
+import { loop } from './patterns/loop.js';
+import type { Agent } from './core/Agent.js';
+
+export async function loadGraph(file: string): Promise<Agent> {
+  const spec = await import(file, { assert: { type: 'json' } }).then((m) => m.default);
+  return build(spec);
+}
+
+function build(node: any): Agent {
+  switch (node.type) {
+    case 'parallel':
+      return parallel(node.children.map(build));
+    case 'sequential':
+      return sequential(node.children.map(build));
+    case 'router':
+      const routes: Record<string, Agent> = {};
+      for (const k in node.routes) routes[k] = build(node.routes[k]);
+      return router(routes);
+    case 'loop':
+      return loop(build(node.child), node.max, node.stopWord);
+    case 'RetrieverAgent':
+      return new (require('./examples/agents/RetrieverAgent.js').RetrieverAgent)();
+    case 'WriterAgent':
+      return new (require('./examples/agents/WriterAgent.js').WriterAgent)();
+    case 'CriticAgent':
+      return new (require('./examples/agents/CriticAgent.js').CriticAgent)();
+    case 'HumanGate':
+      return new (require('./examples/agents/HumanGate.js').HumanGate)();
+    default:
+      throw new Error(`Unknown node type ${node.type}`);
+  }
+}

--- a/agent-framework/src/loader.ts
+++ b/agent-framework/src/loader.ts
@@ -9,26 +9,30 @@ export async function loadGraph(file: string): Promise<Agent> {
   return build(spec);
 }
 
-function build(node: any): Agent {
+async function build(node: any): Promise<Agent> {
   switch (node.type) {
     case 'parallel':
-      return parallel(node.children.map(build));
+      return parallel(await Promise.all(node.children.map(build)));
     case 'sequential':
-      return sequential(node.children.map(build));
+      return sequential(await Promise.all(node.children.map(build)));
     case 'router':
       const routes: Record<string, Agent> = {};
-      for (const k in node.routes) routes[k] = build(node.routes[k]);
+      for (const k in node.routes) routes[k] = await build(node.routes[k]);
       return router(routes);
     case 'loop':
-      return loop(build(node.child), node.max, node.stopWord);
+      return loop(await build(node.child), node.max, node.stopWord);
     case 'RetrieverAgent':
-      return new (require('./examples/agents/RetrieverAgent.js').RetrieverAgent)();
+      const { RetrieverAgent } = await import('./examples/agents/RetrieverAgent.js');
+      return new RetrieverAgent();
     case 'WriterAgent':
-      return new (require('./examples/agents/WriterAgent.js').WriterAgent)();
+      const { WriterAgent } = await import('./examples/agents/WriterAgent.js');
+      return new WriterAgent();
     case 'CriticAgent':
-      return new (require('./examples/agents/CriticAgent.js').CriticAgent)();
+      const { CriticAgent } = await import('./examples/agents/CriticAgent.js');
+      return new CriticAgent();
     case 'HumanGate':
-      return new (require('./examples/agents/HumanGate.js').HumanGate)();
+      const { HumanGate } = await import('./examples/agents/HumanGate.js');
+      return new HumanGate();
     default:
       throw new Error(`Unknown node type ${node.type}`);
   }

--- a/agent-framework/src/patterns/aggregator.ts
+++ b/agent-framework/src/patterns/aggregator.ts
@@ -1,0 +1,14 @@
+import type { Agent } from '../core/Agent.js';
+
+export const aggregator = (agents: Agent[]): Agent => ({
+  id: 'Aggregator',
+  describe: () => 'Merges child observations',
+  async act(input, ctx) {
+    const outputs = [] as string[];
+    for (const a of agents) {
+      const res = await a.act(input, ctx);
+      outputs.push(res.content);
+    }
+    return { content: outputs.join('\n') };
+  },
+});

--- a/agent-framework/src/patterns/hierarchical.ts
+++ b/agent-framework/src/patterns/hierarchical.ts
@@ -1,0 +1,17 @@
+import type { Agent } from '../core/Agent.js';
+
+export const hierarchical = (
+  supervisor: Agent,
+  subordinates: Agent[]
+): Agent => ({
+  id: 'Hierarchical',
+  describe: () => 'Supervisor with subordinate agents',
+  async act(input, ctx) {
+    let msg = input;
+    for (const sub of subordinates) {
+      const out = await sub.act(msg, ctx);
+      msg = out.content;
+    }
+    return supervisor.act(msg, ctx);
+  },
+});

--- a/agent-framework/src/patterns/loop.ts
+++ b/agent-framework/src/patterns/loop.ts
@@ -1,0 +1,18 @@
+import type { Agent } from '../core/Agent.js';
+
+export const loop = (
+  agent: Agent,
+  max = 5,
+  stopWord = 'DONE'
+): Agent => ({
+  id: 'Loop',
+  describe: () => `Iterates until "${stopWord}" or ${max} turns`,
+  async act(input, ctx) {
+    let i = 0;
+    let obs = { content: input };
+    while (!obs.content.includes(stopWord) && ++i <= max) {
+      obs = await agent.act(obs.content, ctx);
+    }
+    return obs;
+  },
+});

--- a/agent-framework/src/patterns/network.ts
+++ b/agent-framework/src/patterns/network.ts
@@ -1,0 +1,25 @@
+import type { Agent } from '../core/Agent.js';
+
+export interface GraphNode {
+  agent: Agent;
+  edges: string[];
+}
+
+export const network = (nodes: Record<string, GraphNode>, root: string): Agent => ({
+  id: 'Network',
+  describe: () => 'Graph-based agent network',
+  async act(input, ctx) {
+    const traverse = async (name: string, msg: string): Promise<string> => {
+      const node = nodes[name];
+      if (!node) return msg;
+      const out = await node.agent.act(msg, ctx);
+      let acc = out.content;
+      for (const edge of node.edges) {
+        acc = await traverse(edge, acc);
+      }
+      return acc;
+    };
+    const content = await traverse(root, input);
+    return { content };
+  },
+});

--- a/agent-framework/src/patterns/parallel.ts
+++ b/agent-framework/src/patterns/parallel.ts
@@ -1,10 +1,10 @@
+import pLimit from 'p-limit';
 import type { Agent } from '../core/Agent.js';
 
 export const parallel = (agents: Agent[]): Agent => ({
   id: 'Parallel',
   describe: () => 'Runs agents in parallel & merges output',
   async act(input, ctx) {
-    const pLimit = (await import('p-limit')).default;
     const limit = pLimit(agents.length);
     const outs = await Promise.all(
       agents.map((a) => limit(() => a.act(input, ctx)))

--- a/agent-framework/src/patterns/parallel.ts
+++ b/agent-framework/src/patterns/parallel.ts
@@ -1,0 +1,14 @@
+import type { Agent } from '../core/Agent.js';
+
+export const parallel = (agents: Agent[]): Agent => ({
+  id: 'Parallel',
+  describe: () => 'Runs agents in parallel & merges output',
+  async act(input, ctx) {
+    const pLimit = (await import('p-limit')).default;
+    const limit = pLimit(agents.length);
+    const outs = await Promise.all(
+      agents.map((a) => limit(() => a.act(input, ctx)))
+    );
+    return { content: outs.map((o) => o.content).join('\n') };
+  },
+});

--- a/agent-framework/src/patterns/router.ts
+++ b/agent-framework/src/patterns/router.ts
@@ -1,0 +1,11 @@
+import type { Agent } from '../core/Agent.js';
+
+export const router = (routes: Record<string, Agent>): Agent => ({
+  id: 'Router',
+  describe: () => `Routes by prefix word`,
+  async act(input, ctx) {
+    const [key, ...rest] = input.trim().split(/\s+/);
+    const target = routes[key] || routes['*'];
+    return target.act(rest.join(' '), ctx);
+  },
+});

--- a/agent-framework/src/patterns/sequential.ts
+++ b/agent-framework/src/patterns/sequential.ts
@@ -1,0 +1,13 @@
+import type { Agent } from '../core/Agent.js';
+
+export const sequential = (chain: Agent[]): Agent => ({
+  id: 'Sequential',
+  describe: () => `Executes ${chain.length} agents in order`,
+  async act(input, ctx) {
+    let acc = input;
+    for (const a of chain) {
+      acc = (await a.act(acc, ctx)).content;
+    }
+    return { content: acc };
+  },
+});

--- a/agent-framework/tsconfig.json
+++ b/agent-framework/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/scripts/setup_agent_framework.sh
+++ b/scripts/setup_agent_framework.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log(){
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+DIR="agent-framework"
+
+if [ -d "$DIR" ]; then
+  log "$DIR already exists, skipping setup"
+  exit 0
+fi
+
+log "Creating $DIR directory"
+mkdir -p "$DIR"
+cd "$DIR"
+
+log "Initializing project"
+npm init -y >/dev/null
+rm -f pnpm-lock.yaml
+
+log "Writing package.json with dependencies"
+cat > package.json <<'EOF'
+{
+  "name": "agent-framework",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.21.0",
+    "p-limit": "^5.0.0",
+    "pinecone-client": "^3.2.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.0",
+    "vitest": "^1.5.0"
+  }
+}
+EOF
+
+log "Creating tsconfig.json"
+cat > tsconfig.json <<'EOF'
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+EOF
+
+log "Creating source directories"
+mkdir -p src/{core,patterns,examples,cli,tests}
+
+log "Setup complete"


### PR DESCRIPTION
## Summary
- add `scripts/setup_agent_framework.sh` for idempotent project scaffolding
- scaffold new `agent-framework` folder with a minimal TypeScript multi-agent system
- implement core abstractions, combinators, reference agents, examples, and CLI loader

## Testing
- `scripts/verify-all.sh` *(fails: Command "markdownlint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fcdbee088331b53362745351a51f