### PR TITLE
Fix instruction & prompt metadata headers

### DIFF
--- a/.github/instructions/general-icon-link-tags.instructions.md
+++ b/.github/instructions/general-icon-link-tags.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "**/*.{html,tsx,jsx}"
-description: "Instructions for implementing a comprehensive set of link tags for favicons and app icons across all platforms."
 ---
 
 # General Icon Link Tags Instructions

--- a/.github/instructions/ios-meta-and-links.instructions.md
+++ b/.github/instructions/ios-meta-and-links.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "public/index.html,src/**/*.html,.well-known/apple-app-site-association"
-description: "Apple Safari & iOS home-screen + Universal Links integration standards"
 ---
 
 # iOS Meta Tags & Universal Links Guide

--- a/.github/instructions/no_dummy-no_placeholders.instruction.md
+++ b/.github/instructions/no_dummy-no_placeholders.instruction.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**"
+---
+
 # Instruction: Code Generation – Real Values over Placeholders
 
 It is essential that all code generated in this repository adheres to the principle of using real, concrete values instead of placeholders or dummy segments. This guideline ensures that all code is immediately executable and functional, enhancing the reliability and quality of our codebase.

--- a/.github/instructions/pwa-manifest.instructions.md
+++ b/.github/instructions/pwa-manifest.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "**/manifest*.json,**/*.webmanifest"
-description: "Progressive Web App (PWA) manifest authoring standards"
 ---
 
 # PWA Manifest Authoring Standards

--- a/.github/instructions/seo-meta-tags.instructions.md
+++ b/.github/instructions/seo-meta-tags.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "**/*.{html,tsx,jsx}"
-description: "Instructions for implementing fundamental SEO meta tags for discoverability, crawling, and social previews."
 ---
 
 # SEO Meta Tags Instructions

--- a/.github/instructions/social-preview-and-deep-links.instructions.md
+++ b/.github/instructions/social-preview-and-deep-links.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "public/index.html,src/**/*.html,.well-known/assetlinks.json"
-description: "Social preview (Open Graph, Twitter Cards) and deep-linking (App Links) meta/configuration"
 ---
 
 # Social Preview & Deep Links Standards

--- a/.github/instructions/theme-ui-meta.instructions.md
+++ b/.github/instructions/theme-ui-meta.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "**/*"
-description: "Detailed instructions for browser-UI theming meta tags"
 ---
 
 # Theme UI Meta Tags

--- a/.github/instructions/validation-debugging-checklist.instructions.md
+++ b/.github/instructions/validation-debugging-checklist.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "**"
-description: "A VS Code–centric checklist for validating and debugging web app meta tags, manifests, icons, deep links, and SEO elements using built-in tools and CLI/CI workflows."
 ---
 
 # Validation & Debugging Checklist Instructions

--- a/.github/instructions/when-to-use-what-matrix.instructions.md
+++ b/.github/instructions/when-to-use-what-matrix.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "**/*"
-description: "One-Page ‘When to Use What’ Matrix mapping integration goals to configuration files"
 ---
 
 # One-Page “When to Use What” Matrix

--- a/.github/instructions/windows-tiles.instructions.md
+++ b/.github/instructions/windows-tiles.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "public/browserconfig.xml,public/index.html,src/**/*.html"
-description: "Windows Tiles (Start-menu & pinned-site) configuration"
 ---
 
 # Windows Tiles Configuration

--- a/.github/instructions/x-cards.instructions.md
+++ b/.github/instructions/x-cards.instructions.md
@@ -1,6 +1,5 @@
 ---
 applyTo: "public/index.html,src/**/*.html"
-description: "X Cards (formerly Twitter Cards) metadata and validation standards"
 ---
 
 # X Cards Metadata Standards

--- a/.github/prompts/docker-exotic-generator.prompt.md
+++ b/.github/prompts/docker-exotic-generator.prompt.md
@@ -1,3 +1,9 @@
+---
+mode: 'agent'
+tools: ['filesystem', 'terminal', 'codebase']
+description: 'Generate advanced Docker configurations with exotic patterns'
+---
+
 # Docker Exotic Configuration Generator
 
 ## Description

--- a/.github/prompts/python-environment-setup.prompt.md
+++ b/.github/prompts/python-environment-setup.prompt.md
@@ -1,3 +1,9 @@
+---
+mode: 'agent'
+tools: ['codebase', 'terminalLastCommand']
+description: 'Guide users through Python environment setup using the conditional framework'
+---
+
 # Python Environment Setup Prompt
 
 ## Context


### PR DESCRIPTION
## Summary
- clean up metadata headers in Copilot instruction files
- add missing header to no_dummy-no_placeholders.instruction.md
- prepend proper metadata to Docker exotic generator and Python env setup prompts

## Testing
- `scripts/verify-all.sh` *(fails: markdownlint not found)*
- `npx markdownlint "**/*.md"` *(fails: E403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6865dbb986508331aa653f5db95a329d