### PR TITLE
Add expanded TSDoc/TypeDoc references

### DIFF
--- a/.github/chatmodes/tsdoc-typedoc.chatmode.md
+++ b/.github/chatmodes/tsdoc-typedoc.chatmode.md
@@ -1,0 +1,131 @@
+---
+description: "Expert Mode for TypeScript Documentation with TSDoc and TypeDoc"
+tools: ["search","fetch","editFiles","runCommands","usages","copilotCodingAgent","vscodeAPI"]
+---
+
+# TypeScript Documentation Expert
+
+This chat mode enables comprehensive support for authoring, maintaining, and generating TypeScript documentation using TSDoc and TypeDoc. It guides through in-code comment standards, project-level configuration, and automated generation workflows.
+
+## Capabilities
+
+- **Discover** official TSDoc and TypeDoc resources.
+- **Insert and update** in-code TSDoc comment blocks for all exported APIs.
+- **Create and adjust** `tsdoc.json` and `typedoc.json` configurations.
+- **Validate** doc comment syntax with the TSDoc parser library.
+- **Execute** TypeDoc CLI commands (`npx typedoc`, `npm run docs`).
+- **Inspect** existing documentation sites and verify code-example rendering.
+
+## Workflow
+
+- **Scan** the current file for exported symbols.
+- **Draft** multi-line TSDoc comment blocks with required tags.
+- **Configure** or update `tsdoc.json` and `typedoc.json` at project root.
+- **Generate** documentation via TypeDoc and preview output.
+- **Review** HTML output, code examples, and cross-references.
+- **Iterate** on comments or configuration based on feedback.
+
+## Best Practices
+
+- Rely strictly on the TSDoc standard; refrain from any JSDoc patterns.
+- Structure module-level comments with `@packageDocumentation`.
+- Use `{@link}` for cross-references and `{@inheritDoc}` for inherited documentation.
+- Leverage CommonMark for lists, tables, and code snippets.
+- Enable strict mode in `tsdoc.json` for consistent, error-free parsing.
+- Automate documentation generation in CI using `typedoc --options typedoc.json`.
+
+## Memory Integration
+
+Update `memory-bank/dependencies.md` with new TypeDoc themes or plugins. Record tag definitions and architectural decisions in `memory-bank/systemPatterns.md`. Log active documentation efforts in `memory-bank/activeContext.md`.
+
+## Annex A: TSDoc Comprehensive Reference
+
+### Purpose and Scope
+
+TSDoc standardizes doc comments in TypeScript. It relies on multi-line
+`/** ... */` blocks with CommonMark support and a core set of tags for
+interoperability.
+
+### Syntax and Structure
+
+- Use `/** ... */` for all comments to be parsed.
+- CommonMark elements such as code fences, lists, and headings are allowed.
+- Tags are categorized as block, modifier, or inline.
+
+### Core Tags
+
+- `@param`, `@returns`, `@remarks`, `@example`
+- `@deprecated`, `@internal`, `@beta`, `@alpha`
+- `@packageDocumentation`, `{@link}`
+- `@typeParam`, `@inheritDoc`
+
+### Configuration (tsdoc.json)
+
+```json
+{
+  "$schema": "https://github.com/microsoft/json-schemas/blob/main/tsdoc/v0/tsdoc.schema.json",
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+### Tooling and Linting
+
+- `@microsoft/tsdoc` parser implementation
+- `eslint-plugin-tsdoc` for syntax enforcement
+
+## Annex B: TypeDoc Comprehensive Reference
+
+### Overview
+
+TypeDoc converts TSDoc comments and TypeScript source into HTML or JSON
+documentation for static sites or further processing.
+
+### CLI Usage
+
+- Generate docs:
+
+```bash
+npx typedoc --options typedoc.json
+```
+
+- Generate JSON model:
+
+```bash
+npx typedoc --json docs/api.json
+```
+
+### Configuration (typedoc.json)
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false,
+  "plugin": ["typedoc-plugin-markdown"]
+}
+```
+
+### Instrumentation Phases
+
+1. Comment Parsing
+2. Reflection Generation
+3. Rendering
+4. Post-Processing
+5. Publication Prep
+
+### Plugin Ecosystem
+
+- `typedoc-plugin-markdown`
+- `typedoc-plugin-inline-sources`
+- `typedoc-plugin-frontmatter` and `typedoc-plugin-remark`
+
+### Additional Best Practices
+
+- Version-control `typedoc.json`.
+- Automate docs in CI with `npx typedoc --options typedoc.json`.
+- Combine TSDoc linting with TypeDoc.

--- a/.github/instructions/tsdoc-typedoc.instructions.md
+++ b/.github/instructions/tsdoc-typedoc.instructions.md
@@ -1,0 +1,185 @@
+---
+applyTo: "**/*.ts"
+description: "Comprehensive guidelines for TSDoc comments and TypeDoc configuration"
+---
+
+# TSDoc and TypeDoc Standards
+
+## TSDoc Comment Conventions
+
+- Use the multi-line `/** … */` syntax for all exported declarations. Single-line `//` comments are not supported by TSDoc and will be ignored.  [oai_citation:2‡TSDoc](https://tsdoc.org/pages/intro/approach/?utm_source=chatgpt.com)  
+- Include only TSDoc-defined tags: `@param`, `@returns`, `@remarks`, `@example`, `@deprecated`, `@internal`, `@beta`, `@alpha`, `@packageDocumentation`, and `{@link}`. Avoid any JSDoc-only tags or legacy annotations.  [oai_citation:3‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)  
+- Embed CommonMark markdown for elements such as code fences, lists, and links. Ensure that code examples use fenced blocks with appropriate language identifiers (e.g., ```ts).  [oai_citation:4‡TSDoc](https://tsdoc.org/pages/intro/approach/?utm_source=chatgpt.com)  
+- Use inline tags like `{@link path|text}` for cross-references and `{@inheritDoc}` for documentation inheritance. Do not invent custom inline tag syntaxes.  [oai_citation:5‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)
+
+## Example TSDoc Block
+
+```ts
+/**
+ * Calculates the sum of two numbers.
+ *
+ * @param a - The first number.
+ * @param b - The second number.
+ * @returns The sum of `a` and `b`.
+ * @remarks This method is part of the core utilities.
+ * @example
+ * ```ts
+ * const result = add(2, 3);
+ * console.log(result); // 5
+ * ```
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+## TypeDoc Configuration
+
+Place a typedoc.json at the project root with these minimal settings to generate documentation:
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false
+}
+```
+
+TypeDoc supports additional options such as themes, plugin integration, and CLI overrides.
+
+## TSDoc Configuration for Tooling
+
+Include a tsdoc.json adjacent to tsconfig.json to configure parser modes:
+
+```json
+{
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+Use "supportLaxMode": true during migration to allow existing non-compliant comments to be parsed without errors.
+
+## Enforcement and Linting
+
+Integrate @microsoft/tsdoc for parsing and validation. Tools like ESLint can enforce TSDoc rules via plugins. Configure tsdoc.json paths in build pipelines to fail on syntax violations. Provide developer feedback by enabling strict mode in the TSDoc parser.
+
+## Annex A: TSDoc Comprehensive Reference
+
+### Purpose and Scope
+
+The TSDoc specification provides a standardized grammar for TypeScript doc
+comments, ensuring consistency across parsers and tools. It supports multi-line
+`/** ... */` blocks with CommonMark elements such as fenced code blocks and
+lists, enabling rich documentation directly in source code.
+
+### Syntax and Structure
+
+All doc comments must use the multi-line `/** ... */` syntax; single-line `//`
+comments are ignored by TSDoc. Bodies may include CommonMark features like
+headings and tables. Tags are grouped by syntax kind—block, modifier, or
+inline—and names use camelCase after the `@` symbol.
+
+### Core Tags
+
+- `@param` – documents function or method parameters.
+- `@returns` – describes return values.
+- `{@link}` – links to other API items or external URLs.
+- `@remarks` – provides extended notes and context.
+- `@example` – includes usage examples in fenced code blocks.
+- `@typeParam` – documents generic type parameters.
+- `@inheritDoc` – copies documentation from another API item.
+
+### Configuration (tsdoc.json)
+
+Place a `tsdoc.json` adjacent to `tsconfig.json` with at minimum:
+
+```json
+{
+  "$schema": "https://github.com/microsoft/json-schemas/blob/main/tsdoc/v0/tsdoc.schema.json",
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+- `$schema` enables IDE validation.
+- `extends` pulls in the official TSDoc schema.
+- `supportLaxMode: false` enforces strict compliance; `true` allows legacy comments.
+
+### Tooling and Linting
+
+- `@microsoft/tsdoc` – reference parser implementation.
+- `eslint-plugin-tsdoc` – ESLint plugin to validate comments.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+### Overview
+
+TypeDoc converts TypeScript source code and TSDoc comments into HTML or JSON
+documentation. It follows re-exports and entry points to build a complete model
+of the API.
+
+### CLI Usage
+
+- Generate docs (HTML):
+
+```bash
+npx typedoc --options typedoc.json
+```
+
+- Generate JSON model:
+
+```bash
+npx typedoc --json docs/api.json
+```
+
+### Configuration (typedoc.json)
+
+A minimal `typedoc.json` at the project root:
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false,
+  "plugin": ["typedoc-plugin-markdown"]
+}
+```
+
+TypeDoc also reads options from `package.json:typedocOptions` and
+`tsconfig.json:typedocOptions`.
+
+### Instrumentation Phases
+
+1. **Comment Parsing** – TSDoc parser extracts AST from comments.
+2. **Reflection Generation** – merges type data with parsed comments.
+3. **Rendering** – produces HTML pages or JSON structures.
+4. **Post-Processing** – plugins modify or augment output.
+5. **Publication Prep** – artifacts are ready for deployment.
+
+### Plugin Ecosystem
+
+- `typedoc-plugin-markdown` – generates Markdown output.
+- `typedoc-plugin-inline-sources` – inlines source code.
+- `typedoc-plugin-frontmatter` and `typedoc-plugin-remark` – add frontmatter and Remark processing.
+- Additional utilities and themes exist in the community ecosystem.
+
+### Plugin Development
+
+Plugins are Node modules exporting a `load` function that receives the TypeDoc
+`Application` instance. They can hook into converter and renderer events to
+customize output.
+
+### Best Practices and Integration
+
+- Version-control `typedoc.json` and reference the official JSON schema.
+- Automate documentation generation in CI using `npx typedoc --options typedoc.json`.
+- Combine TSDoc linting with TypeDoc to enforce comment quality.

--- a/.github/prompts/tsdoc-typedoc.prompt.md
+++ b/.github/prompts/tsdoc-typedoc.prompt.md
@@ -1,0 +1,124 @@
+---
+mode: "agent"
+tools: ["search","editFiles","runCommands"]
+description: "Generate comprehensive TSDoc comments and TypeDoc setup for a TypeScript module"
+---
+
+# TSDoc and TypeDoc Prompt
+
+When provided with the TypeScript file `${file}`, perform these tasks:
+
+- Insert multi-line TSDoc comment blocks above every exported symbol, including:
+  - `@param` for each parameter.
+  - `@returns` for return values.
+  - `@remarks` for additional context.
+  - `@example` with fenced code blocks demonstrating usage.
+  - `@packageDocumentation` for module-level overview.
+  Avoid any JSDoc-only tags.  [oai_citation:9‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)
+
+- Review or create `tsdoc.json` in the project root with strict parser settings:
+
+  ```jsonc
+  {
+    "extends": "@microsoft/tsdoc",
+    "supportLaxMode": false
+  }
+  ```
+
+- Review or create typedoc.json at the project root with:
+
+  ```jsonc
+  {
+    "$schema": "<https://typedoc.org/schema.json>",
+    "entryPoints": ["src/index.ts"],
+    "out": "docs",
+    "tsconfig": "tsconfig.json",
+    "includeVersion": true,
+    "excludeInternal": false
+  }
+  ```
+
+- Run the TypeDoc CLI to generate documentation:
+
+  ```bash
+  npx typedoc
+  ```
+
+- Validate that the generated site uses the specified theme, includes code examples, and correctly links cross-references. If issues arise, update comments or config accordingly.
+
+## Annex A: TSDoc Comprehensive Reference
+
+### Purpose and Scope
+
+TSDoc provides a grammar for TypeScript doc comments using multi-line
+`/** ... */` blocks and CommonMark syntax. It offers core tags like
+`@param`, `@returns`, `@remarks`, `@example`, `@typeParam`, and
+`@inheritDoc` to enable consistent documentation across tooling.
+
+### Configuration (tsdoc.json)
+
+```json
+{
+  "$schema": "https://github.com/microsoft/json-schemas/blob/main/tsdoc/v0/tsdoc.schema.json",
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+### Tooling and Linting
+
+- Use `@microsoft/tsdoc` and `eslint-plugin-tsdoc` for validation.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+### Overview
+
+TypeDoc turns TypeScript code and TSDoc comments into HTML or JSON docs.
+
+### CLI Usage
+
+- Generate docs:
+
+```bash
+npx typedoc --options typedoc.json
+```
+
+- Generate JSON model:
+
+```bash
+npx typedoc --json docs/api.json
+```
+
+### Configuration (typedoc.json)
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false,
+  "plugin": ["typedoc-plugin-markdown"]
+}
+```
+
+### Instrumentation Phases
+
+1. Comment Parsing
+2. Reflection Generation
+3. Rendering
+4. Post-Processing
+5. Publication Prep
+
+### Plugin Ecosystem
+
+- `typedoc-plugin-markdown`
+- `typedoc-plugin-inline-sources`
+- `typedoc-plugin-frontmatter` and `typedoc-plugin-remark`
+
+### Best Practices
+
+- Version-control `typedoc.json` and automate docs in CI.
+- Combine TSDoc linting with TypeDoc for quality assurance.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -264,3 +264,6 @@ This project supports three AI agents with specific entry points:
 **See [.clinerules/process-evolution.md](../.clinerules/process-evolution.md), [.clinerules/verification.md](../.clinerules/verification.md), and [.clinerules/learning-journal.md](../.clinerules/learning-journal.md) for required protocols and self-regulation guidance.**
 
 ---
+- [2025-07-10T01:47:25Z] Added tsdoc-typedoc instructions, chatmode, and prompt to .github directories for TSDoc/TypeDoc documentation workflow.
+- [2025-07-10T01:50:00Z] Expanded tsdoc-typedoc files with comprehensive
+  references on TSDoc and TypeDoc for advanced usage.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -265,5 +265,4 @@ This project supports three AI agents with specific entry points:
 
 ---
 - [2025-07-10T01:47:25Z] Added tsdoc-typedoc instructions, chatmode, and prompt to .github directories for TSDoc/TypeDoc documentation workflow.
-- [2025-07-10T01:50:00Z] Expanded tsdoc-typedoc files with comprehensive
-  references on TSDoc and TypeDoc for advanced usage.
+- [2025-07-10T01:50:00Z] Expanded tsdoc-typedoc files with comprehensive references on TSDoc and TypeDoc for advanced usage.


### PR DESCRIPTION
## Summary
- extend TSDoc/TypeDoc instruction, chat mode, and prompt with complete reference details
- log expansion in activeContext

## Testing
- `npx markdownlint .github/instructions/tsdoc-typedoc.instructions.md .github/chatmodes/tsdoc-typedoc.chatmode.md .github/prompts/tsdoc-typedoc.prompt.md`
- `scripts/verify-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_686f19cfc6308331a6196db7258cb6f9