### PR TITLE
Add comprehensive TSDoc/TypeDoc references

### DIFF
--- a/.github/chatmodes/tsdoc-typedoc.chatmode.md
+++ b/.github/chatmodes/tsdoc-typedoc.chatmode.md
@@ -1,0 +1,54 @@
+---
+description: "Expert Mode for TypeScript Documentation with TSDoc and TypeDoc"
+tools: ["search","fetch","editFiles","runCommands","usages","copilotCodingAgent","vscodeAPI"]
+---
+
+# TypeScript Documentation Expert
+
+This chat mode enables comprehensive support for authoring, maintaining, and generating TypeScript documentation using TSDoc and TypeDoc. It guides through in-code comment standards, project-level configuration, and automated generation workflows.
+
+## Capabilities
+
+- **Discover** official TSDoc and TypeDoc resources.
+- **Insert and update** in-code TSDoc comment blocks for all exported APIs.
+- **Create and adjust** `tsdoc.json` and `typedoc.json` configurations.
+- **Validate** doc comment syntax with the TSDoc parser library.
+- **Execute** TypeDoc CLI commands (`npx typedoc`, `npm run docs`).
+- **Inspect** existing documentation sites and verify code-example rendering.
+
+## Workflow
+
+- **Scan** the current file for exported symbols.
+- **Draft** multi-line TSDoc comment blocks with required tags.
+- **Configure** or update `tsdoc.json` and `typedoc.json` at project root.
+- **Generate** documentation via TypeDoc and preview output.
+- **Review** HTML output, code examples, and cross-references.
+- **Iterate** on comments or configuration based on feedback.
+
+## Best Practices
+
+- Rely strictly on the TSDoc standard; refrain from any JSDoc patterns.
+- Structure module-level comments with `@packageDocumentation`.
+- Use `{@link}` for cross-references and `{@inheritDoc}` for inherited documentation.
+- Leverage CommonMark for lists, tables, and code snippets.
+- Enable strict mode in `tsdoc.json` for consistent, error-free parsing.
+- Automate documentation generation in CI using `typedoc --options typedoc.json`.
+
+## Memory Integration
+
+Update `memory-bank/dependencies.md` with new TypeDoc themes or plugins. Record tag definitions and architectural decisions in `memory-bank/systemPatterns.md`. Log active documentation efforts in `memory-bank/activeContext.md`.
+
+---
+
+## Annex A: TSDoc Comprehensive Reference
+
+The TSDoc specification standardizes multi-line comment blocks and supports CommonMark syntax. Core tags include `@param`, `@returns`, `@remarks`, `@example`, `{@link}`, `@typeParam`, and `@inheritDoc`. Configure strict parsing via `tsdoc.json` with the official schema reference.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+TypeDoc generates HTML or JSON documentation from TypeScript. Use `typedoc.json` for configuration and run `npx typedoc` to build docs. Instrumentation phases parse comments, generate reflections, render output, and allow plugin-driven post-processing. Common plugins include `typedoc-plugin-markdown` and `typedoc-plugin-inline-sources`.
+
+## Verification
+
+- `markdownlint --strict` .github/chatmodes/tsdoc-typedoc.chatmode.md
+- `scripts/verify-all.sh`

--- a/.github/instructions/tsdoc-typedoc.instructions.md
+++ b/.github/instructions/tsdoc-typedoc.instructions.md
@@ -1,0 +1,183 @@
+---
+applyTo: "**/*.ts"
+description: "Comprehensive guidelines for TSDoc comments and TypeDoc configuration"
+---
+
+# TSDoc and TypeDoc Standards
+
+## TSDoc Comment Conventions
+
+- Use the multi-line `/** … */` syntax for all exported declarations. Single-line `//` comments are not supported by TSDoc and will be ignored.  [oai_citation:2‡TSDoc](https://tsdoc.org/pages/intro/approach/?utm_source=chatgpt.com)  
+- Include only TSDoc-defined tags: `@param`, `@returns`, `@remarks`, `@example`, `@deprecated`, `@internal`, `@beta`, `@alpha`, `@packageDocumentation`, and `{@link}`. Avoid any JSDoc-only tags or legacy annotations.  [oai_citation:3‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)  
+- Embed CommonMark markdown for elements such as code fences, lists, and links. Ensure that code examples use fenced blocks with appropriate language identifiers (e.g., ```ts).  [oai_citation:4‡TSDoc](https://tsdoc.org/pages/intro/approach/?utm_source=chatgpt.com)  
+- Use inline tags like `{@link path|text}` for cross-references and `{@inheritDoc}` for documentation inheritance. Do not invent custom inline tag syntaxes.  [oai_citation:5‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)
+
+## Example TSDoc Block
+
+```ts
+/**
+ * Calculates the sum of two numbers.
+ *
+ * @param a - The first number.
+ * @param b - The second number.
+ * @returns The sum of `a` and `b`.
+ * @remarks This method is part of the core utilities.
+ * @example
+ * ```ts
+ * const result = add(2, 3);
+ * console.log(result); // 5
+ * ```
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+## TypeDoc Configuration
+
+Place a typedoc.json at the project root with these minimal settings to generate documentation:
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false
+}
+```
+
+TypeDoc supports additional options such as themes, plugin integration, and CLI overrides.
+
+## TSDoc Configuration for Tooling
+
+Include a tsdoc.json adjacent to tsconfig.json to configure parser modes:
+
+```json
+{
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+Use "supportLaxMode": true during migration to allow existing non-compliant comments to be parsed without errors.
+
+## Enforcement and Linting
+
+Integrate @microsoft/tsdoc for parsing and validation. Tools like ESLint can enforce TSDoc rules via plugins. Configure tsdoc.json paths in build pipelines to fail on syntax violations. Provide developer feedback by enabling strict mode in the TSDoc parser.
+
+---
+
+## Annex A: TSDoc Comprehensive Reference
+
+### Purpose and Scope
+
+The TSDoc specification provides a standardized grammar for TypeScript doc comments, ensuring consistency across toolchains. It supports multi-line comment blocks with embedded CommonMark elements.
+
+### Syntax and Structure
+
+- All doc comments must use the multi-line `/** ... */` syntax; single-line `//` comments are ignored by TSDoc.
+- Bodies may include CommonMark constructs such as fenced code blocks (` ```ts `), tables, and headings.
+- Tags are distinguished by their syntax kind—block, modifier, or inline—and names must use camelCase following an `@` sign.
+
+### Core Tags
+
+- `@param` – documents function or method parameters.
+- `@returns` – describes return values of functions or methods.
+- `{@link}` – creates hyperlinks to other API items or external URLs.
+- `@remarks` – adds extended notes and context.
+- `@example` – includes usage examples in fenced code blocks.
+- `@typeParam` – documents generic type parameters.
+- `@inheritDoc` – copies documentation from another API item.
+
+### Configuration (`tsdoc.json`)
+
+Place a `tsdoc.json` adjacent to your tsconfig.json with at minimum:
+
+```json
+{
+  "$schema": "https://github.com/microsoft/json-schemas/blob/main/tsdoc/v0/tsdoc.schema.json",
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+- The `$schema` reference enables IDE validation.
+- `extends`: `@microsoft/tsdoc` pulls in the official TSDoc schema.
+- `supportLaxMode`: `false` enforces strict compliance, while `true` allows legacy comments during migration.
+
+### Tooling and Linting
+
+- **@microsoft/tsdoc** – the reference parser implementation for TSDoc.
+- **eslint-plugin-tsdoc** – ESLint plugin validating that comments conform to TSDoc.
+
+---
+
+## Annex B: TypeDoc Comprehensive Reference
+
+### Overview
+
+TypeDoc generates documentation from TypeScript source and TSDoc comments, producing HTML or JSON outputs. It follows re-exports and entry points to build a complete model of your API.
+
+### CLI Usage
+
+- **Generate docs (HTML):** `npx typedoc --options typedoc.json`
+- **Generate JSON model:** `npx typedoc --json docs/api.json`
+
+### Configuration (`typedoc.json`)
+
+A minimal `typedoc.json` at the project root:
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false,
+  "plugin": ["typedoc-plugin-markdown"]
+}
+```
+
+TypeDoc also reads options from `package.json:typedocOptions` and `tsconfig.json:typedocOptions`.
+
+### Instrumentation Phases
+
+1. **Comment Parsing** – delegates to the TSDoc/markdown parser to extract AST from comments.
+2. **Reflection Generation** – merges TypeScript compiler type data with parsed comments to build a reflection model.
+3. **Rendering** – transforms reflections into HTML pages or JSON structures.
+4. **Post-Processing** – plugins modify or augment output (e.g., Markdown conversion).
+5. **Publication Prep** – output artifacts are ready for deployment or further tooling.
+
+### Plugin Ecosystem
+
+- **typedoc-plugin-markdown** – generates Markdown output.
+- **typedoc-plugin-inline-sources** – inlines source code into documentation.
+- **typedoc-plugin-frontmatter** and **typedoc-plugin-remark** – add frontmatter and Remark processing.
+- Additional utilities and themes exist in the typedoc-plugin-markdown ecosystem.
+
+### Plugin Development
+
+Plugins are Node modules exporting a `load` function that receives the TypeDoc `Application` instance. They can hook into events such as `Converter.EVENT_CREATE_DECLARATION` and renderer hooks (`comment.beforeTags`, `comment.afterTags`) to customize output.
+
+### Best Practices and Integration
+
+- Version-control your `typedoc.json` and reference the official JSON schema.
+- Automate documentation generation in CI pipelines via `npx typedoc --options typedoc.json`.
+- Combine TSDoc linting (`eslint-plugin-tsdoc`) with TypeDoc in CI to enforce comment quality.
+
+### References
+
+- TSDoc Specification: <https://tsdoc.org/pages/spec/overview/>
+- TSDoc JSON Schema: <https://github.com/microsoft/json-schemas/blob/master/tsdoc/v0/tsdoc.schema.json>
+- TypeDoc Plugins: <https://typedoc.org/documents/Plugins.html>
+- typedoc-plugin-markdown: <https://typedoc-plugin-markdown.org>
+
+## Verification
+
+- `markdownlint --strict` .github/instructions/tsdoc-typedoc.instructions.md
+- `scripts/verify-all.sh`

--- a/.github/prompts/tsdoc-typedoc.prompt.md
+++ b/.github/prompts/tsdoc-typedoc.prompt.md
@@ -1,0 +1,62 @@
+---
+mode: "agent"
+tools: ["search","editFiles","runCommands"]
+description: "Generate comprehensive TSDoc comments and TypeDoc setup for a TypeScript module"
+---
+
+# TSDoc and TypeDoc Prompt
+
+When provided with the TypeScript file `${file}`, perform these tasks:
+
+- Insert multi-line TSDoc comment blocks above every exported symbol, including:
+  - `@param` for each parameter.
+  - `@returns` for return values.
+  - `@remarks` for additional context.
+  - `@example` with fenced code blocks demonstrating usage.
+  - `@packageDocumentation` for module-level overview.
+  Avoid any JSDoc-only tags.  [oai_citation:9‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)
+
+- Review or create `tsdoc.json` in the project root with strict parser settings:
+
+  ```jsonc
+  {
+    "extends": "@microsoft/tsdoc",
+    "supportLaxMode": false
+  }
+  ```
+
+- Review or create typedoc.json at the project root with:
+
+  ```jsonc
+  {
+    "$schema": "<https://typedoc.org/schema.json>",
+    "entryPoints": ["src/index.ts"],
+    "out": "docs",
+    "tsconfig": "tsconfig.json",
+    "includeVersion": true,
+    "excludeInternal": false
+  }
+  ```
+
+- Run the TypeDoc CLI to generate documentation:
+
+  ```bash
+  npx typedoc
+  ```
+
+- Validate that the generated site uses the specified theme, includes code examples, and correctly links cross-references. If issues arise, update comments or config accordingly.
+
+---
+
+## Annex A: TSDoc Comprehensive Reference
+
+Use multi-line `/** ... */` comment blocks with CommonMark support. Core tags include `@param`, `@returns`, `@remarks`, `@example`, `{@link}`, `@typeParam`, and `@inheritDoc`. Configure strict parsing via `tsdoc.json` with the official schema.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+Run `npx typedoc --options typedoc.json` to generate HTML documentation or `npx typedoc --json docs/api.json` for a JSON model. The `typedoc.json` file should reference the official schema and may load plugins such as `typedoc-plugin-markdown`.
+
+## Verification
+
+- `markdownlint --strict` .github/prompts/tsdoc-typedoc.prompt.md
+- `scripts/verify-all.sh`

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -92,7 +92,7 @@ This file tracks the current work focus, recent changes, next steps, and active 
 
 Successfully converted entire Questrade SDK codebase from node-fetch to native fetch API, maintaining full functionality and test coverage. All 259 tests pass with TypeScript compilation successful.
 
-### Key Achievements:
+### Key Achievements
 
 - **✅ Complete node-fetch Removal:** Eliminated external dependency in favor of native Node.js 22 fetch API
 - **✅ Type System Modernization:** Updated all Response types from FetchResponse to native Response interface
@@ -101,7 +101,7 @@ Successfully converted entire Questrade SDK codebase from node-fetch to native f
 - **✅ Dependency Reduction:** Removed one external package dependency for cleaner dependency tree
 - **✅ Future Compatibility:** Native fetch API provides better long-term maintenance and compatibility
 
-### Conversion Details:
+### Conversion Details
 
 - **Source Files Updated:** src/errors/smartFetch.ts, src/errors/toError.ts, src/errors/handle.ts, src/http/restClient.ts
 - **Test Files Updated:** src/tests/restClient.test.ts (recreated after corruption), src/tests/error.test.ts
@@ -109,7 +109,7 @@ Successfully converted entire Questrade SDK codebase from node-fetch to native f
 - **Type Annotations:** Changed all `FetchResponse` references to native `Response` type
 - **Test Mocking:** Updated from module mocking to global stubbing for better test isolation
 
-### Memory Bank Synchronization Implementation:
+### Memory Bank Synchronization Implementation
 
 - **✅ Protocol Established:** Implemented comprehensive memory bank synchronization in .github/copilot-instructions.md
 - **✅ State Preservation:** Documented imperative requirements for reading, updating, and preserving context
@@ -120,7 +120,7 @@ Successfully converted entire Questrade SDK codebase from node-fetch to native f
 
 Successfully resolved all test failures and achieved comprehensive branch coverage for the TypeScript SDK test suite. All 259 tests now pass with 98.34% branch coverage, exceeding project requirements.
 
-### Key Achievements:
+### Key Achievements (Test Suite Optimization)
 
 - **✅ Fixed Original Test Failures:** Resolved 3 failing restClient.test.ts tests using proper vi.mock('node-fetch') strategy
 - **✅ 98.34% Branch Coverage:** Exceeded 90% threshold requirement across entire test suite
@@ -131,7 +131,7 @@ Successfully resolved all test failures and achieved comprehensive branch covera
 - **✅ Test Isolation:** Eliminated real network requests and external dependencies
 - **✅ CommonJS Compatibility:** Maintained existing module system throughout improvements
 
-### Testing Framework Implementation:
+### Testing Framework Implementation
 
 - **Vitest with Istanbul Coverage:** 257 tests passing with detailed branch/statement/function/line reporting
 - **Module Mocking:** `vi.mock('node-fetch')` for HTTP client testing without network requests
@@ -264,3 +264,5 @@ This project supports three AI agents with specific entry points:
 **See [.clinerules/process-evolution.md](../.clinerules/process-evolution.md), [.clinerules/verification.md](../.clinerules/verification.md), and [.clinerules/learning-journal.md](../.clinerules/learning-journal.md) for required protocols and self-regulation guidance.**
 
 ---
+- [2025-07-10T01:47:25Z] Added tsdoc-typedoc instructions, chatmode, and prompt to .github directories for TSDoc/TypeDoc documentation workflow.
+- [2025-07-10T02:45:00Z] Appended comprehensive TSDoc and TypeDoc references to instruction, chat mode, and prompt files; added verification sections.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -259,7 +259,7 @@ Successfully completed implementation of conditional Python environment framewor
 - **Scalable**: Pattern can be extended to other language environments
 - **AI-Agent Compatible**: Works seamlessly with all three AI agents
 - **User-Centric**: Defers decisions to users rather than making assumptions
-- **Documentation Enhanced**: Integrated comprehensive TSDoc and TypeDoc reference sections with verification blocks.
+- **Documentation Enhanced**: Integrated comprehensive TSDoc and TypeDoc reference sections with verification blocks
 
 ### Next Milestone
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -259,6 +259,7 @@ Successfully completed implementation of conditional Python environment framewor
 - **Scalable**: Pattern can be extended to other language environments
 - **AI-Agent Compatible**: Works seamlessly with all three AI agents
 - **User-Centric**: Defers decisions to users rather than making assumptions
+- **Documentation Enhanced**: Integrated comprehensive TSDoc and TypeDoc reference sections with verification blocks.
 
 ### Next Milestone
 


### PR DESCRIPTION
## Summary
- expand TSDoc/TypeDoc instruction with full reference annexes
- append reference notes to chat mode and prompt
- add verification sections to all three files
- log update in activeContext and progress

## Testing
- `npx markdownlint .github/instructions/tsdoc-typedoc.instructions.md .github/chatmodes/tsdoc-typedoc.chatmode.md .github/prompts/tsdoc-typedoc.prompt.md memory-bank/activeContext.md memory-bank/progress.md`
- `scripts/verify-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_686f19cfc6308331a6196db7258cb6f9