### PR TITLE
Expand TSDoc/TypeDoc guidance

### DIFF
--- a/.github/chatmodes/tsdoc-typedoc.chatmode.md
+++ b/.github/chatmodes/tsdoc-typedoc.chatmode.md
@@ -1,0 +1,63 @@
+---
+description: "Expert Mode for TypeScript Documentation with TSDoc and TypeDoc"
+tools: ["search","fetch","editFiles","runCommands","usages","copilotCodingAgent","vscodeAPI"]
+---
+
+# TypeScript Documentation Expert
+
+This chat mode enables comprehensive support for authoring, maintaining, and generating TypeScript documentation using TSDoc and TypeDoc. It guides through in-code comment standards, project-level configuration, and automated generation workflows.
+
+## Capabilities
+
+- **Discover** official TSDoc and TypeDoc resources.
+- **Insert and update** in-code TSDoc comment blocks for all exported APIs.
+- **Create and adjust** `tsdoc.json` and `typedoc.json` configurations.
+- **Validate** doc comment syntax with the TSDoc parser library.
+- **Execute** TypeDoc CLI commands (`npx typedoc`, `npm run docs`).
+- **Inspect** existing documentation sites and verify code-example rendering.
+
+## Workflow
+
+- **Scan** the current file for exported symbols.
+- **Draft** multi-line TSDoc comment blocks with required tags.
+- **Configure** or update `tsdoc.json` and `typedoc.json` at project root.
+- **Generate** documentation via TypeDoc and preview output.
+- **Review** HTML output, code examples, and cross-references.
+- **Iterate** on comments or configuration based on feedback.
+
+## Best Practices
+
+- Rely strictly on the TSDoc standard; refrain from any JSDoc patterns.
+- Structure module-level comments with `@packageDocumentation`.
+- Use `{@link}` for cross-references and `{@inheritDoc}` for inherited documentation.
+- Leverage CommonMark for lists, tables, and code snippets.
+- Enable strict mode in `tsdoc.json` for consistent, error-free parsing.
+- Automate documentation generation in CI using `typedoc --options typedoc.json`.
+
+## Memory Integration
+
+Update `memory-bank/dependencies.md` with new TypeDoc themes or plugins. Record tag definitions and architectural decisions in `memory-bank/systemPatterns.md`. Log active documentation efforts in `memory-bank/activeContext.md`.
+
+## Annex A: TSDoc Comprehensive Reference
+
+- TSDoc mandates `/** */` comment blocks with CommonMark formatting.
+- Supported tags include `@param`, `@returns`, `@remarks`, `@example`,
+  `@deprecated`, `@internal`, `@beta`, `@alpha`, `@packageDocumentation`,
+  `@typeParam`, `@inheritDoc` and inline `{@link}`.
+- Configure the parser via `tsdoc.json` extending `@microsoft/tsdoc` and set
+  `supportLaxMode` only during migration.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+- Generates HTML or JSON from TypeScript sources and TSDoc comments.
+- Configuration lives in `typedoc.json` with the official schema reference and
+  optional plugins such as `typedoc-plugin-markdown`.
+- Run `npx typedoc` to build docs or `npx typedoc --json docs/api.json` for a
+  JSON model.
+- Documentation generation follows phases: parsing, reflection, rendering,
+  post-processing and publication.
+
+## Verification
+
+- `markdownlint --strict` on updated Markdown files
+- `scripts/verify-all.sh`

--- a/.github/instructions/tsdoc-typedoc.instructions.md
+++ b/.github/instructions/tsdoc-typedoc.instructions.md
@@ -1,0 +1,105 @@
+---
+applyTo: "**/*.ts"
+description: "Comprehensive guidelines for TSDoc comments and TypeDoc configuration"
+---
+
+# TSDoc and TypeDoc Standards
+
+## TSDoc Comment Conventions
+
+- Use the multi-line `/** … */` syntax for all exported declarations. Single-line `//` comments are not supported by TSDoc and will be ignored.  [oai_citation:2‡TSDoc](https://tsdoc.org/pages/intro/approach/?utm_source=chatgpt.com)  
+- Include only TSDoc-defined tags: `@param`, `@returns`, `@remarks`, `@example`, `@deprecated`, `@internal`, `@beta`, `@alpha`, `@packageDocumentation`, and `{@link}`. Avoid any JSDoc-only tags or legacy annotations.  [oai_citation:3‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)  
+- Embed CommonMark markdown for elements such as code fences, lists, and links. Ensure that code examples use fenced blocks with appropriate language identifiers (e.g., ```ts).  [oai_citation:4‡TSDoc](https://tsdoc.org/pages/intro/approach/?utm_source=chatgpt.com)  
+- Use inline tags like `{@link path|text}` for cross-references and `{@inheritDoc}` for documentation inheritance. Do not invent custom inline tag syntaxes.  [oai_citation:5‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)
+
+## Example TSDoc Block
+
+```ts
+/**
+ * Calculates the sum of two numbers.
+ *
+ * @param a - The first number.
+ * @param b - The second number.
+ * @returns The sum of `a` and `b`.
+ * @remarks This method is part of the core utilities.
+ * @example
+ * ```ts
+ * const result = add(2, 3);
+ * console.log(result); // 5
+ * ```
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+## TypeDoc Configuration
+
+Place a typedoc.json at the project root with these minimal settings to generate documentation:
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "tsconfig": "tsconfig.json",
+  "includeVersion": true,
+  "excludeInternal": false
+}
+```
+
+TypeDoc supports additional options such as themes, plugin integration, and CLI overrides.
+
+## TSDoc Configuration for Tooling
+
+Include a tsdoc.json adjacent to tsconfig.json to configure parser modes:
+
+```json
+{
+  "extends": "@microsoft/tsdoc",
+  "tagDefinitions": [],
+  "supportLaxMode": false
+}
+```
+
+Use "supportLaxMode": true during migration to allow existing non-compliant comments to be parsed without errors.
+
+## Enforcement and Linting
+
+Integrate @microsoft/tsdoc for parsing and validation. Tools like ESLint can enforce TSDoc rules via plugins. Configure tsdoc.json paths in build pipelines to fail on syntax violations. Provide developer feedback by enabling strict mode in the TSDoc parser.
+
+## Annex A: TSDoc Comprehensive Reference
+
+- **Purpose and Scope**: TSDoc defines a grammar for TypeScript doc comments using
+  multi-line blocks with CommonMark support to enable tooling interoperability.
+- **Syntax**: comments use `/** */` delimiters exclusively and may embed fenced
+  code, lists and headings.
+- **Core Tags**: `@param`, `@returns`, `@remarks`, `@example`, `@deprecated`,
+  `@internal`, `@beta`, `@alpha`, `@packageDocumentation`, `@typeParam`,
+  `@inheritDoc` and inline `{@link}`.
+- **Configuration**: place a `tsdoc.json` next to `tsconfig.json` with the
+  `$schema` reference `https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json`.
+- **Tooling**: use `@microsoft/tsdoc` for parsing, `@microsoft/tsdoc-config` to
+  load definitions and `eslint-plugin-tsdoc` to lint comments.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+- **Overview**: TypeDoc converts TypeScript sources and TSDoc comments into HTML
+  or JSON documentation models.
+- **Configuration**: `typedoc.json` should reference
+  `https://typedoc.org/schema.json` and can include plugins such as
+  `typedoc-plugin-markdown`.
+- **CLI Usage**:
+  - Generate HTML with `npx typedoc` or `typedoc --options typedoc.json`.
+  - Produce a JSON model with `npx typedoc --json docs/api.json`.
+- **Instrumentation Phases**: comment parsing, reflection generation, rendering,
+  post-processing via plugins and publication.
+- **Plugin Ecosystem**: community plugins provide Markdown output, inline source
+  code and custom themes.
+- **Best Practices**: enforce strict TSDoc syntax in CI and version-control both
+  configuration files.
+
+## Verification
+
+- `markdownlint --strict` on updated Markdown files
+- `scripts/verify-all.sh`

--- a/.github/prompts/tsdoc-typedoc.prompt.md
+++ b/.github/prompts/tsdoc-typedoc.prompt.md
@@ -1,0 +1,69 @@
+---
+mode: "agent"
+tools: ["search","editFiles","runCommands"]
+description: "Generate comprehensive TSDoc comments and TypeDoc setup for a TypeScript module"
+---
+
+# TSDoc and TypeDoc Prompt
+
+When provided with the TypeScript file `${file}`, perform these tasks:
+
+- Insert multi-line TSDoc comment blocks above every exported symbol, including:
+  - `@param` for each parameter.
+  - `@returns` for return values.
+  - `@remarks` for additional context.
+  - `@example` with fenced code blocks demonstrating usage.
+  - `@packageDocumentation` for module-level overview.
+  Avoid any JSDoc-only tags.  [oai_citation:9‡TSDoc](https://tsdoc.org/?utm_source=chatgpt.com)
+
+- Review or create `tsdoc.json` in the project root with strict parser settings:
+
+  ```jsonc
+  {
+    "extends": "@microsoft/tsdoc",
+    "supportLaxMode": false
+  }
+  ```
+
+- Review or create typedoc.json at the project root with:
+
+  ```jsonc
+  {
+    "$schema": "<https://typedoc.org/schema.json>",
+    "entryPoints": ["src/index.ts"],
+    "out": "docs",
+    "tsconfig": "tsconfig.json",
+    "includeVersion": true,
+    "excludeInternal": false
+  }
+  ```
+
+- Run the TypeDoc CLI to generate documentation:
+
+  ```bash
+  npx typedoc
+  ```
+
+- Validate that the generated site uses the specified theme, includes code examples, and correctly links cross-references. If issues arise, update comments or config accordingly.
+
+## Annex A: TSDoc Comprehensive Reference
+
+- Use multi-line `/** */` blocks with CommonMark syntax.
+- Key tags: `@param`, `@returns`, `@remarks`, `@example`, `@deprecated`,
+  `@internal`, `@beta`, `@alpha`, `@packageDocumentation`, `@typeParam`,
+  `@inheritDoc`, `{@link}`.
+- Configure strict parsing via `tsdoc.json` next to `tsconfig.json`.
+
+## Annex B: TypeDoc Comprehensive Reference
+
+- `typedoc.json` references `https://typedoc.org/schema.json` and may load
+  plugins such as `typedoc-plugin-markdown`.
+- Build HTML with `npx typedoc` or generate JSON using
+  `npx typedoc --json docs/api.json`.
+- Documentation rendering proceeds through parsing, reflection, rendering,
+  plugin post-processing and final publication.
+
+## Verification
+
+- `markdownlint --strict` on updated Markdown files
+- `scripts/verify-all.sh`

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -264,3 +264,5 @@ This project supports three AI agents with specific entry points:
 **See [.clinerules/process-evolution.md](../.clinerules/process-evolution.md), [.clinerules/verification.md](../.clinerules/verification.md), and [.clinerules/learning-journal.md](../.clinerules/learning-journal.md) for required protocols and self-regulation guidance.**
 
 ---
+- [2025-07-10T01:47:25Z] Added tsdoc-typedoc instructions, chatmode, and prompt to .github directories for TSDoc/TypeDoc documentation workflow.
+- [2025-07-10T02:22:00Z] Expanded tsdoc-typedoc files with comprehensive Annex A and Annex B references and added verification blocks.


### PR DESCRIPTION
## Summary
- extend tsdoc-typedoc instructions with annex references
- expand chat mode and prompt accordingly and add verification blocks
- log updates in activeContext

## Testing
- `npx markdownlint .github/instructions/tsdoc-typedoc.instructions.md .github/chatmodes/tsdoc-typedoc.chatmode.md .github/prompts/tsdoc-typedoc.prompt.md`
- `scripts/verify-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_686f19cfc6308331a6196db7258cb6f9