### PR TITLE
feat(web): add dev server tasks

### DIFF
--- a/.github/prompts/start-web-dev-server.prompt.md
+++ b/.github/prompts/start-web-dev-server.prompt.md
@@ -1,0 +1,23 @@
+---
+mode: 'agent'
+description: 'Launch the Next.js development server from the web directory.'
+---
+
+# 🚀 Start Web Dev Server Prompt
+
+## Goal
+
+Start the local Next.js development server located in `web/`.
+
+## Steps
+
+1. Open an integrated terminal.
+2. Change directory to `web/`.
+3. Run `pnpm dev`.
+4. Ensure the terminal displays the running port (default `http://localhost:3000`).
+5. Monitor the console for any errors.
+
+## Verification
+
+- `markdownlint --strict` on this file
+- `scripts/verify-all.sh`

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -243,6 +243,40 @@
         "focus": false,
         "panel": "shared"
       }
+    },
+    {
+      "label": "Web: Dev Server",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["dev"],
+      "options": {
+        "cwd": "${workspaceFolder}/web"
+      },
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Web: Build",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["build"],
+      "options": {
+        "cwd": "${workspaceFolder}/web"
+      },
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,13 @@
 <!-- markdownlint-disable MD013 MD041 MD022 MD032 -->
 
+## [2025-07-14T06:24:39Z] Self-Documentation Log
+- [2025-07-14T06:24:39Z] Current State: VS Code tasks added for Next.js development;
+  Last Action: Created "Web: Dev Server" and "Web: Build" tasks in `.vscode/tasks.json` and added `start-web-dev-server.prompt.md` for Copilot assistance;
+  Rationale: Automate launching and building the web app via VS Code as requested by the user;
+  Next Intent: Run the new tasks to verify the server starts correctly and document results;
+  Note: Executing Self-Documentation Protocol.
+  This entry reaffirms that all actions and context changes must be documented and that this rule itself is part of the ongoing protocol.
+
 ## [2025-07-13T11:07:00Z] Self-Documentation Log
 
 - [2025-07-13T11:07:00Z] Current State: Comprehensive README drift resolution and Memory Bank synchronization completed;

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -273,3 +273,4 @@ Successfully completed implementation of conditional Python environment framewor
 - Test the complete conditional framework across all three modes
 - Document lessons learned for extending to other language environments
 - Consider implementing conditional frameworks for Node.js, TypeScript, and web development setups
+- Add VS Code tasks for Next.js dev server and build


### PR DESCRIPTION
## Summary
- add VS Code tasks for Next.js dev server and build
- document dev server prompt for Copilot
- update active context and progress

## Testing
- `npx markdownlint --config .markdownlint.yaml memory-bank/activeContext.md memory-bank/progress.md .github/prompts/start-web-dev-server.prompt.md` *(fails: multiple lint errors in pre-existing text)*
- `./scripts/verify-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68749b6449f883319bade861f1dd3c4e