### PR TITLE
Update docs & scripts for memory-bank locations

### DIFF
--- a/.github/README.copilotmd
+++ b/.github/README.copilotmd
@@ -194,7 +194,7 @@ preferences and instructions.
 
 ### Documentation and User Preferences
 
-- All documentation for instructions and prompts MUST be included in respective `.github/instructions/README.md` and `.github/prompts/README.md` files. Do not use a `docs/` folder unless explicitly required by user.
+- All documentation for instructions and prompts MUST be included in respective `memory-bank/instructions/README.md` and `memory-bank/prompts/README.md` files. Do not use a `docs/` folder unless explicitly required by user.
 - When possible, append user preferences and operational requirements to `.github/copilot-instructions.md` and reference them in future actions.
 - When generating or updating instruction or prompt files, self-prompt to update documentation and preferences as part of workflow.
 - This policy is recommended for all future Copilot and agent operations in this repository.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -235,7 +235,7 @@ preferences and instructions.
 
 ### Documentation and User Preferences
 
-- All documentation for instructions and prompts MUST be included in respective `.github/instructions/README.md` and `.github/prompts/README.md` files. Do not use a `docs/` folder unless explicitly required by user.
+ - All documentation for instructions and prompts MUST be included in respective `memory-bank/instructions/README.md` and `memory-bank/prompts/README.md` files. Do not use a `docs/` folder unless explicitly required by user.
 - When possible, append user preferences and operational requirements to `.github/copilot-instructions.md` and reference them in future actions.
 - When generating or updating instruction or prompt files, self-prompt to update documentation and preferences as part of workflow.
 - This policy is recommended for all future Copilot and agent operations in this repository.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,8 @@
     "docker-compose*.yml": "dockercompose",
     "*.md": "markdown",
     "**/.github/chatmodes/*.chatmode.md": "chatmode",
-    "**/.github/instructions/*.instructions.md": "instructions",
-    "**/.github/prompts/*.prompt.md": "prompt",
+    "**/memory-bank/instructions/*.instructions.md": "instructions",
+    "**/memory-bank/prompts/*.prompt.md": "prompt",
     "**/memory-bank/chatmodes/*.chatmode.md": "chatmode",
     "**/memory-bank/prompts/*.prompt.md": "prompt",
     "**/memory-bank/instructions/*.instructions.md": "instructions"
@@ -2102,11 +2102,9 @@
   },
   "chat.promptFiles": true,
   "chat.promptFilesLocations": {
-    ".github/prompts": true,
     "memory-bank/prompts": true
   },
   "chat.instructionsFilesLocations": {
-    ".github/instructions": true,
     "memory-bank/instructions": true
   },
   "chat.implicitContext.enabled": {

--- a/memory-bank/chatmodes/planification-agent/script-optimization-review-plan.md
+++ b/memory-bank/chatmodes/planification-agent/script-optimization-review-plan.md
@@ -105,8 +105,8 @@ This implementation plan addresses the user's request for a comprehensive review
 
 **Actions**:
 1. **Memory Bank Cross-References**: Validate all links in `dependencies.md`, `activeContext.md`, `progress.md`
-2. **Instruction File References**: Check all `.github/instructions/` files for accurate script references
-3. **Prompt File References**: Validate all `.github/prompts/` files for current workflow accuracy
+2. **Instruction File References**: Check all `memory-bank/instructions/` files for accurate script references
+3. **Prompt File References**: Validate all `memory-bank/prompts/` files for current workflow accuracy
 4. **Task Configuration**: Ensure `.vscode/tasks.json` reflects consolidated script structure
 
 **Validation Criteria**:

--- a/memory-bank/chatmodes/questrade-sdk-developer.chatmode.md
+++ b/memory-bank/chatmodes/questrade-sdk-developer.chatmode.md
@@ -98,7 +98,7 @@ When user signals a focus on codebase structure, you must immediately and proact
 > At inception of this session and during thereafter, you must ensure that memory bank is initialized and updated with latest context and actions. This is crucial for maintaining state and continuity in development at beginning [Initialize Memory Bank NOW!](../prompts/memory-bank-update.prompt.md).
 
 - Always reference latest Questrade API documentation and `src/` folder for context.
-- Enforce TypeScript standards and project-specific guidelines from `.github/instructions/typescript-standards.instructions.md` and related files.
+- Enforce TypeScript standards and project-specific guidelines from `memory-bank/instructions/typescript-standards.instructions.md` and related files.
 - Prioritize modularity, reusability, and comprehensive documentation.
 - Implement strong error handling, rate-limiting, and security throughout SDK.
 - Ensure all changes are reflected in `src/main.ts` (entry point) and `src/index.ts` (barrel file for named and default exports).

--- a/memory-bank/chatmodes/vscode-helper.chatmode.md
+++ b/memory-bank/chatmodes/vscode-helper.chatmode.md
@@ -27,8 +27,8 @@ You are in vscode-helper chatmode. Your task is to assist with VS Code developme
 
 ### Project Standards Compliance
 
-- Follow TypeScript standards from `.github/instructions/typescript-standards.instructions.md`.
-- Ensure compliance with file organization rules from `.github/instructions/file-organization.instructions.md`.
+- Follow TypeScript standards from `memory-bank/instructions/typescript-standards.instructions.md`.
+- Ensure compliance with file organization rules from `memory-bank/instructions/file-organization.instructions.md`.
 - Apply coding standards and best practices.
 - **Proactively identify and report any code that deviates from established standards, suggesting a refactoring plan.**
 - Maintain memory bank synchronization per `.github/copilot-instructions.md`.
@@ -80,7 +80,7 @@ description: '<short description>' # Optional. Shown on hover in Chat view.
 - The `applyTo` property is required and determines which files or tasks the instructions apply to (glob pattern).
 - The `description` property is optional and provides a summary for UI display.
 - The body contains the actual instructions, written in Markdown.
-- Place workspace instruction files in `.github/instructions/`.
+ - Place workspace instruction files in `memory-bank/instructions/`.
 - User instruction files are stored in your VS Code profile folder.
 
 **Best Practices:**
@@ -145,7 +145,7 @@ description: '<short description>' # Optional. Shown in UI.
 ## Centrally Manage Instructions and Prompt Files
 
 - Enable or disable instructions and prompt files with the `chat.promptFiles` setting.
-- By default, workspace instruction files are in `.github/instructions/` and prompt files in `.github/prompts/`.
+ - By default, workspace instruction files are in `memory-bank/instructions/` and prompt files in `memory-bank/prompts/`.
 - You can add more folders using `chat.instructionsFilesLocations` and `chat.promptFilesLocations` settings.
 - For organization-wide management, use VS Code's enterprise settings management.
 

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -92,8 +92,8 @@ This file tracks all pro### Script Management and Optimization Protocol
 
 ### Instruction & Prompt Framework
 **Depends On:** tsconfig.json baseUrl and paths configuration, TypeScript standards from `memory-bank/instructions/`
-- **26 Instruction Files** - Automated coding standards in `.github/instructions/`
-- **27 Prompt Files** - Executable workflow templates in `.github/prompts/`
+- **26 Instruction Files** - Automated coding standards in `memory-bank/instructions/`
+- **27 Prompt Files** - Executable workflow templates in `memory-bank/prompts/`
 All agents must consult the [when-to-use-what-matrix.instructions.md](../memory-bank/instructions/when-to-use-what-matrix.instructions.md) for a one-page mapping of integration goals to configuration files and authoritative sources. For detailed implementation, see `memory-bank/instructions/README.md` and `memory-bank/prompts/README.md`.
 - **Conditional Architecture** - Runtime decision frameworks
 - **Parameter-Driven Configuration** - ENV_MODE and similar runtime selection
@@ -202,7 +202,7 @@ This project supports three AI agents with specific dependency management respon
 
 **All agents must maintain dependency tracking in this file and ensure cross-references remain accurate.**
 
-**For meta-configuration standards, consult [when-to-use-what-matrix.instructions.md](../.github/instructions/when-to-use-what-matrix.instructions.md) for authoritative mapping of integration goals to configuration files.**
+**For meta-configuration standards, consult [when-to-use-what-matrix.instructions.md](../instructions/when-to-use-what-matrix.instructions.md) for authoritative mapping of integration goals to configuration files.**
 
 ---
 
@@ -290,9 +290,9 @@ This file tracks all project dependencies, their relationships, and integration 
 
 - **Memory Bank System**: Cross-referencing and documentation framework
 
-- **Prompt Files**: Executable workflow templates in `.github/prompts/`
+ - **Prompt Files**: Executable workflow templates in `memory-bank/prompts/`
 
-- **Instruction Files**: Coding standards and guidelines in `.github/instructions/`
+ - **Instruction Files**: Coding standards and guidelines in `memory-bank/instructions/`
 
 - **Script System**: Automation tools in `scripts/` directory
 
@@ -402,9 +402,9 @@ This file tracks all project dependencies, their relationships, and integration 
 
 ## AI Agent Dependencies
 
-### Prompt Files (`.github/prompts/`)
+### Prompt Files (`memory-bank/prompts/`)
 
-### Prompt Files (`.github/prompts/`)
+### Prompt Files (`memory-bank/prompts/`)
 
 - **codex-universal-environment.prompt.md**: Comprehensive Docker environment management
   - **Depends On**: `memory-bank/docker-workflow.md`, Docker environment instruction files
@@ -444,9 +444,9 @@ This file tracks all project dependencies, their relationships, and integration 
   - **Required By**: Jupyter notebook development, data science workflows, ML experimentation
   - **Integration**: VS Code extended capabilities, notebook-specialist chat mode, memory bank synchronization
 
-### Instruction Files (`.github/instructions/`)
+### Instruction Files (`memory-bank/instructions/`)
 
-### Instruction Files (`.github/instructions/`)
+### Instruction Files (`memory-bank/instructions/`)
 
 - **docker-environment.instructions.md**: Comprehensive Docker environment standards
   - **Depends On**: `memory-bank/docker-workflow.md`, container security best practices
@@ -491,11 +491,11 @@ This file tracks all project dependencies, their relationships, and integration 
 ### Conditional Python Environment Integration
 
 ```
-.github/instructions/python-environment-conditional.instructions.md
+memory-bank/instructions/python-environment-conditional.instructions.md
 ├── Defines: Three-mode conditional setup (local, docker_isolated, docker_volume)
 ├── Parameters: ENV_MODE, PYTHON_VERSION, PROJECT_NAME
 ├── Integrates: AI agent collaboration patterns
-└── Enables: .github/prompts/python-environment-setup.prompt.md
+└── Enables: memory-bank/prompts/python-environment-setup.prompt.md
     ├── Presents: Mode selection to users
     ├── Routes: scripts/setup_python_env.sh
     ├── Generates: Mode-specific configurations and documentation
@@ -519,8 +519,8 @@ scripts/setup_python_env.sh (main entry)
 
 ```
 User Request → GitHub Copilot/Cline AI/Codex CLI
-├── Reads: .github/prompts/python-environment-setup.prompt.md
-├── Applies: .github/instructions/python-environment-conditional.instructions.md
+├── Reads: memory-bank/prompts/python-environment-setup.prompt.md
+├── Applies: memory-bank/instructions/python-environment-conditional.instructions.md
 ├── References: memory-bank/docker-workflow.md (for Docker modes)
 ├── Executes: scripts/setup_python_env.sh with chosen ENV_MODE
 ├── Generates: Mode-specific configurations and documentation
@@ -611,7 +611,7 @@ Project Root
 #### Jest with TypeScript Path Aliases (2025-06-22)
 
 **Rationale:** Enables clean import paths using @/ alias for src/ directory in tests, improving maintainability and following modern TypeScript practices.
-**Depends On:** tsconfig.json baseUrl and paths configuration, TypeScript standards from .github/instructions/
+**Depends On:** tsconfig.json baseUrl and paths configuration, TypeScript standards from memory-bank/instructions/
 **Required By:** All test files in src/tests/ directory structure
 **Impact Analysis:** Enables mirrored directory structure in tests with clean imports, supporting comprehensive test coverage goals.
 
@@ -640,10 +640,10 @@ This project supports three AI agents with specific dependency management respon
 
 **Meta-Configuration & Manifest Standards:**
 
-All agents must consult the [when-to-use-what-matrix.instructions.md](../.github/instructions/when-to-use-what-matrix.instructions.md) for a one-page mapping of integration goals to configuration files and authoritative sources. For detailed implementation, see `.github/instructions/README.md` and `.github/prompts/README.md`.
+All agents must consult the [when-to-use-what-matrix.instructions.md](../instructions/when-to-use-what-matrix.instructions.md) for a one-page mapping of integration goals to configuration files and authoritative sources. For detailed implementation, see `memory-bank/instructions/README.md` and `memory-bank/prompts/README.md`.
 
 **UI Theming Standards:**
-All agents must consult the [theme-ui-meta.instructions.md](../.github/instructions/theme-ui-meta.instructions.md) for detailed theming meta tag standards and the [theme-ui-meta.prompt.md](../.github/prompts/theme-ui-meta.prompt.md) for workflow automation. These files cover syntax, validation, and platform-specific quirks for `theme-color`, `color-scheme`, and related tags.
+All agents must consult the [theme-ui-meta.instructions.md](../instructions/theme-ui-meta.instructions.md) for detailed theming meta tag standards and the [theme-ui-meta.prompt.md](../prompts/theme-ui-meta.prompt.md) for workflow automation. These files cover syntax, validation, and platform-specific quirks for `theme-color`, `color-scheme`, and related tags.
 
 ---
 

--- a/memory-bank/instructions/README.md
+++ b/memory-bank/instructions/README.md
@@ -282,7 +282,7 @@ When adding new instructions:
 Instructions are enabled in VS Code through:
 
 - `github.copilot.chat.codeGeneration.useInstructionFiles: true`
-- `github.copilot.chat.codeGeneration.instructionsPath: ".github/instructions"`
+- `github.copilot.chat.codeGeneration.instructionsPath: "memory-bank/instructions"`
 
 See [.vscode/settings.json](../../.vscode/settings.json) for current configuration.
 

--- a/memory-bank/instructions/edge-devtools-debugging.instructions.md
+++ b/memory-bank/instructions/edge-devtools-debugging.instructions.md
@@ -544,4 +544,4 @@ Update `memory-bank/progress.md` with:
 
 ---
 
-**Note**: This instruction file follows the strict protocol requirements for `.github/instructions/` directory. All settings and configurations must be applied through proper VS Code settings and launch configuration files. No unauthorized files should be created in `.vscode/` directory beyond standard VS Code configuration files.
+**Note**: This instruction file follows the strict protocol requirements for `memory-bank/instructions/` directory. All settings and configurations must be applied through proper VS Code settings and launch configuration files. No unauthorized files should be created in `.vscode/` directory beyond standard VS Code configuration files.

--- a/memory-bank/instructions/when-to-use-what-matrix.instructions.md
+++ b/memory-bank/instructions/when-to-use-what-matrix.instructions.md
@@ -35,7 +35,7 @@ This matrix condenses all key manifest and meta configurations into a single ref
    - RealFaviconGenerator / Windows Tile Checker ([speckyboy.com][4])
    - Android Studio App Links Assistant ([developer.android.com][15])
 
-4. **Document** results in `.github/prompts/README.md` and `.github/instructions/README.md`.
+4. **Document** results in `memory-bank/prompts/README.md` and `memory-bank/instructions/README.md`.
 
 > ⚠️ Ensure this file remains at the project root or alongside other `.instructions.md` files—**do not** place in a `docs/` folder.
 

--- a/memory-bank/prompts/file-organization.prompt.md
+++ b/memory-bank/prompts/file-organization.prompt.md
@@ -28,8 +28,8 @@ description: 'Comprehensive standards for file and directory organization, namin
 
 ## Prompt and Instruction File Organization
 
-- Place all prompt files in `.github/prompts/` directory
-- Place all instruction files in `.github/instructions/` directory
+- Place all prompt files in `memory-bank/prompts/` directory
+- Place all instruction files in `memory-bank/instructions/` directory
 - Use kebab-case naming convention for all files
 - Follow pattern: `{domain}-{purpose}.{type}.md`
 - Type is one of `prompt` or `instruction`
@@ -155,9 +155,9 @@ description: 'Comprehensive standards for file and directory organization, namin
 5. Configuration, Metadata & Version Control
    .vscode/
    .github/
-   .github/instructions/
-   .github/prompts/
-   .github/chatmodes/
+   memory-bank/instructions/
+   memory-bank/prompts/
+   memory-bank/chatmodes/
 6. IMPERATIVE memory-bank/
    memory-bank/
 7. Configuration, Alternative AI Assistants Metadata

--- a/memory-bank/prompts/self-documentation.prompt.md
+++ b/memory-bank/prompts/self-documentation.prompt.md
@@ -16,8 +16,8 @@ Your goal is to log and reinforce every action or context change by appending a 
 ## Process
 
 1. **Read Protocols**
-   - Load `.clinerules/reading-protocol.md` and  
-     `.github/instructions/self-documentation.instructions.md`.
+   - Load `.clinerules/reading-protocol.md` and
+     `memory-bank/instructions/self-documentation.instructions.md`.
 
 2. **Detect Trigger**
    - Identify the action or context change event (e.g., file creation, prompt execution).

--- a/memory-bank/prompts/template-manager.prompt.md
+++ b/memory-bank/prompts/template-manager.prompt.md
@@ -23,7 +23,7 @@ Apply this decision tree to **every** user request:
 #### Instructions Files (Persistent Rules)
 
 - **Global workspace rules**: `.github/copilot-instructions.md` (auto-applied to all requests)
-- **Scoped rules**: `.github/instructions/{domain}.instructions.md` with `applyTo` frontmatter
+- **Scoped rules**: `memory-bank/instructions/{domain}.instructions.md` with `applyTo` frontmatter
 - **Language/framework specific**: Use glob patterns like `**/*.ts`, `**/*.py`, `**/tests/**`
 
 #### Prompt Files (Reusable Workflows)
@@ -175,7 +175,7 @@ onRequest(userRequest):
 
 ```
 User: "Always use TypeScript strict mode and prefer interfaces over types"
-→ Updates/creates: .github/instructions/typescript.instructions.md
+→ Updates/creates: memory-bank/instructions/typescript.instructions.md
 → Adds applyTo: "**/*.ts,**/*.tsx"
 ```
 
@@ -192,7 +192,7 @@ User: "I need a reusable workflow for creating React components with tests"
 ```
 User: "Add Python docstring requirements to existing Python standards"
 → Searches: Existing Python instruction files
-→ Updates: .github/instructions/python-standards.instructions.md
+→ Updates: memory-bank/instructions/python-standards.instructions.md
 ```
 
 ## Post-Creation Actions

--- a/notebooks/openai/openai_api_prototyping.ipynb
+++ b/notebooks/openai/openai_api_prototyping.ipynb
@@ -224,7 +224,7 @@
     "- [ ] Additional experiments documented\n",
     "- [ ] Results reproducible in clean environment\n",
     "\n",
-    "> For more details, see [python-notebook-standards.instructions.md](../../.github/instructions/python-notebook-standards.instructions.md)"
+    "> For more details, see [python-notebook-standards.instructions.md](../../memory-bank/instructions/python-notebook-standards.instructions.md)"
    ]
   }
  ],

--- a/notebooks/openai_api_prototyping.ipynb
+++ b/notebooks/openai_api_prototyping.ipynb
@@ -188,7 +188,7 @@
     "- [ ] Additional experiments documented\n",
     "- [ ] Results reproducible in clean environment\n",
     "\n",
-    "> For more details, see [python-notebook-standards.instructions.md](../.github/instructions/python-notebook-standards.instructions.md)\n"
+    "> For more details, see [python-notebook-standards.instructions.md](../memory-bank/instructions/python-notebook-standards.instructions.md)\n"
    ]
   }
  ],

--- a/python/README.md
+++ b/python/README.md
@@ -131,5 +131,5 @@ python/
 ```
 
 For more information, see:
-- Instructions: `../.github/instructions/python-environment-conditional.instructions.md`
-- Prompt: `../.github/prompts/python-environment-setup.prompt.md`
+- Instructions: `../memory-bank/instructions/python-environment-conditional.instructions.md`
+- Prompt: `../memory-bank/prompts/python-environment-setup.prompt.md`

--- a/scripts/autonomous-state-manager.sh
+++ b/scripts/autonomous-state-manager.sh
@@ -71,13 +71,13 @@ scan_project_changes() {
   local changes_detected=false
 
   # Check for new .prompt.md files
-  if find "$PROJECT_ROOT/.github/prompts" -name "*.prompt.md" -newer "$MEMORY_BANK/progress.md" 2> /dev/null | grep -q .; then
+  if find "$PROJECT_ROOT/memory-bank/prompts" -name "*.prompt.md" -newer "$MEMORY_BANK/progress.md" 2> /dev/null | grep -q .; then
     update_progress "CREATED" "New Prompt Files" "ACTIVE"
     changes_detected=true
   fi
 
   # Check for new .instructions.md files
-  if find "$PROJECT_ROOT/.github/instructions" -name "*.instructions.md" -newer "$MEMORY_BANK/progress.md" 2> /dev/null | grep -q .; then
+  if find "$PROJECT_ROOT/memory-bank/instructions" -name "*.instructions.md" -newer "$MEMORY_BANK/progress.md" 2> /dev/null | grep -q .; then
     update_progress "CREATED" "New Instruction Files" "ACTIVE"
     changes_detected=true
   fi

--- a/scripts/generate-instruction-file.sh
+++ b/scripts/generate-instruction-file.sh
@@ -6,7 +6,7 @@
 #? Purpose: Automate creation of instruction files for AI agent framework
 #? Decision Rationale: Provides consistent templates for coding standards, architecture, security, etc.
 #? Usage: ./generate-instruction-file.sh -n <filename> -a <apply_to_glob> -d <description> [-t <type>]
-#? Dependencies: bash, .github/instructions/, .github/prompts/
+#? Dependencies: bash, memory-bank/instructions/, memory-bank/prompts/
 #? Last Updated: 2025-07-23 by GitHub Copilot
 #? References: ai-instruction-creation.instructions.md, instruction-generator.prompt.md
 ## =============================================================================
@@ -15,13 +15,13 @@
 
 # AI Agent Framework - Instruction File Generator
 # This script creates new .instructions.md files, providing structured templates
-# to be populated based on .github/instructions/ai-instruction-creation.instructions.md
+# to be populated based on memory-bank/instructions/ai-instruction-creation.instructions.md
 
 set -euo pipefail
 
 # Configuration
-INSTRUCTIONS_DIR=".github/instructions"
-PROMPTS_DIR=".github/prompts"
+INSTRUCTIONS_DIR="memory-bank/instructions"
+PROMPTS_DIR="memory-bank/prompts"
 # Reference to the prompt that would be used by an AI to fill the generated template
 GENERATOR_PROMPT_FOR_AI_FILLING="$PROMPTS_DIR/instruction-generator.prompt.md"
 
@@ -273,7 +273,7 @@ EOF
 - <!-- Guideline B: Provide examples for complex rules. -->
 
 <!-- Add more sections as needed based on the specific standards being defined. -->
-<!-- Refer to .github/instructions/ai-instruction-creation.instructions.md for comprehensive guidance on how an AI should populate this file. -->
+<!-- Refer to memory-bank/instructions/ai-instruction-creation.instructions.md for comprehensive guidance on how an AI should populate this file. -->
 EOF
       ;;
   esac
@@ -305,7 +305,7 @@ EOF
 
   log_success "Generated instruction file template: $filepath"
   log_info "Please populate this file with specific rules."
-  log_info "An AI can assist with this, guided by .github/instructions/ai-instruction-creation.instructions.md and potentially using $GENERATOR_PROMPT_FOR_AI_FILLING."
+  log_info "An AI can assist with this, guided by memory-bank/instructions/ai-instruction-creation.instructions.md and potentially using $GENERATOR_PROMPT_FOR_AI_FILLING."
 }
 
 # Update dependencies.md with new instruction file
@@ -356,7 +356,7 @@ EXAMPLES:
 
 The generated file will be placed in $INSTRUCTIONS_DIR/. It provides a skeleton
 to be filled with specific rules, ideally with AI assistance guided by
-.github/instructions/ai-instruction-creation.instructions.md.
+memory-bank/instructions/ai-instruction-creation.instructions.md.
 EOF
 }
 

--- a/scripts/generate-prompt-file.sh
+++ b/scripts/generate-prompt-file.sh
@@ -4,7 +4,7 @@
 #? Purpose: Automate creation of prompt files for AI-assisted development workflows
 #? Decision Rationale: Provides consistent templates for reusable prompts
 #? Usage: ./generate-prompt-file.sh -n <filename> -t <title> -d <description>
-#? Dependencies: bash, .github/prompts/, memory-bank/dependencies.md
+#? Dependencies: bash, memory-bank/prompts/, memory-bank/dependencies.md
 #? Last Updated: 2025-07-23 by GitHub Copilot
 #? References: ai-prompt-creation.instructions.md, instruction-generator.prompt.md
 ## =============================================================================
@@ -19,8 +19,8 @@
 set -euo pipefail
 
 # Configuration
-PROMPTS_DIR=".github/prompts"
-INSTRUCTIONS_DIR=".github/instructions"
+PROMPTS_DIR="memory-bank/prompts"
+INSTRUCTIONS_DIR="memory-bank/instructions"
 
 # Colors for output
 RED='\033[0;31m'
@@ -263,10 +263,10 @@ You are working in a VS Code workspace with the following project structure:
 ## Instructions Integration
 
 Apply the following instruction files during code generation:
-- \`.github/instructions/typescript-standards.instructions.md\` for TypeScript code
-- \`.github/instructions/python-standards.instructions.md\` for Python code
-- \`.github/instructions/python-notebook-standards.instructions.md\` for Jupyter notebooks
-- \`.github/instructions/file-organization.instructions.md\` for project structure
+- \`memory-bank/instructions/typescript-standards.instructions.md\` for TypeScript code
+- \`memory-bank/instructions/python-standards.instructions.md\` for Python code
+- \`memory-bank/instructions/python-notebook-standards.instructions.md\` for Jupyter notebooks
+- \`memory-bank/instructions/file-organization.instructions.md\` for project structure
 
 ## Parametric Inputs
 
@@ -387,10 +387,10 @@ Provide the following deliverables:
 ## Related Files
 
 ### Prompt Files
-<!-- List related prompt files in .github/prompts/ -->
+<!-- List related prompt files in memory-bank/prompts/ -->
 
 ### Instruction Files
-<!-- List applicable instruction files in .github/instructions/ -->
+<!-- List applicable instruction files in memory-bank/instructions/ -->
 
 ### Memory Bank Files
 <!-- List relevant files in memory-bank/ -->
@@ -423,7 +423,7 @@ update_dependencies() {
 
   if [[ -f "$dependencies_file" ]]; then
     log_info "Don't forget to update $dependencies_file with the new prompt file dependencies"
-    log_info "Add entry for: .github/prompts/$filename"
+    log_info "Add entry for: memory-bank/prompts/$filename"
   else
     log_warning "Dependencies file not found: $dependencies_file"
   fi

--- a/scripts/init-empty-copilot-project.sh
+++ b/scripts/init-empty-copilot-project.sh
@@ -14,7 +14,8 @@
 #!/bin/bash
 
 # Create necessary directories
-mkdir -p .github/prompts
+mkdir -p memory-bank/prompts
+mkdir -p memory-bank/instructions
 mkdir -p memory-bank
 mkdir -p .vscode
 mkdir -p .clinerules
@@ -24,7 +25,7 @@ mkdir -p .clinerules
 # Create necessary files without overwriting existing ones.
 [ -f .github/copilot-instructions.md ] || touch .github/copilot-instructions.md
 [ -f AGENTS.md ] || touch AGENTS.md
-[ -f .github/prompts/default.prompt.md ] || touch .github/prompts/default.prompt.md
+[ -f memory-bank/prompts/default.prompt.md ] || touch memory-bank/prompts/default.prompt.md
 [ -f .vscode/settings.json ] || touch .vscode/settings.json
 
 echo "✅ VSCode Copilot structure created safely."

--- a/scripts/setup_python_docker_isolated.sh
+++ b/scripts/setup_python_docker_isolated.sh
@@ -267,8 +267,8 @@ python/
 \`\`\`
 
 For more information, see:
-- Instructions: \`../.github/instructions/python-environment-conditional.instructions.md\`
-- Prompt: \`../.github/prompts/python-environment-setup.prompt.md\`
+- Instructions: \`../memory-bank/instructions/python-environment-conditional.instructions.md\`
+- Prompt: \`../memory-bank/prompts/python-environment-setup.prompt.md\`
 EOF
 
 success "Updated README.md with Docker isolated instructions"

--- a/scripts/setup_python_docker_volume.sh
+++ b/scripts/setup_python_docker_volume.sh
@@ -407,8 +407,8 @@ python/
 \`\`\`
 
 For more information, see:
-- Instructions: \`../.github/instructions/python-environment-conditional.instructions.md\`
-- Prompt: \`../.github/prompts/python-environment-setup.prompt.md\`
+- Instructions: \`../memory-bank/instructions/python-environment-conditional.instructions.md\`
+- Prompt: \`../memory-bank/prompts/python-environment-setup.prompt.md\`
 EOF
 
 success "Updated README.md with Docker volume-mounted instructions"

--- a/scripts/setup_python_local.sh
+++ b/scripts/setup_python_local.sh
@@ -251,8 +251,8 @@ python/
 \`\`\`
 
 For more information, see:
-- Instructions: \`../.github/instructions/python-environment-conditional.instructions.md\`
-- Prompt: \`../.github/prompts/python-environment-setup.prompt.md\`
+- Instructions: \`../memory-bank/instructions/python-environment-conditional.instructions.md\`
+- Prompt: \`../memory-bank/prompts/python-environment-setup.prompt.md\`
 EOF
 
 log "Verifying Markdown compliance…"

--- a/scripts/validate-instructions.sh
+++ b/scripts/validate-instructions.sh
@@ -6,9 +6,9 @@
 #? Purpose: Run markdownlint on instruction files to ensure consistent formatting and adherence to markdown standards
 #? Decision Rationale: Maintains documentation quality and consistency across all instruction files using automated linting
 #? Usage: ./validate-instructions.sh
-#? Dependencies: markdownlint, .markdownlint.yaml config, .github/instructions/*.instructions.md files
+#? Dependencies: markdownlint, .markdownlint.yaml config, memory-bank/instructions/*.instructions.md files
 #? Last Updated: 2025-07-24 by GitHub Copilot
-#? References: .github/instructions/ directory, .markdownlint.yaml
+#? References: memory-bank/instructions/ directory, .markdownlint.yaml
 ## =============================================================================
 set -euo pipefail
 
@@ -16,7 +16,7 @@ log() {
   echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
 }
 
-pattern=".github/instructions/*.instructions.md"
+pattern="memory-bank/instructions/*.instructions.md"
 
 log "Linting instructions files"
 npx prettier --write $pattern

--- a/scripts/validate-prompt.sh
+++ b/scripts/validate-prompt.sh
@@ -6,9 +6,9 @@
 #? Purpose: Run markdownlint on prompt files to ensure consistent formatting and adherence to markdown standards
 #? Decision Rationale: Maintains documentation quality and consistency across all prompt files using automated linting
 #? Usage: ./validate-prompt.sh
-#? Dependencies: markdownlint, .markdownlint.yaml config, .github/prompts/*.prompt.md files
+#? Dependencies: markdownlint, .markdownlint.yaml config, memory-bank/prompts/*.prompt.md files
 #? Last Updated: 2025-07-24 by GitHub Copilot
-#? References: .github/prompts/ directory, .markdownlint.yaml
+#? References: memory-bank/prompts/ directory, .markdownlint.yaml
 ## =============================================================================
 set -euo pipefail
 
@@ -16,7 +16,7 @@ log() {
   echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
 }
 
-pattern=".github/prompts/*.prompt.md"
+pattern="memory-bank/prompts/*.prompt.md"
 
 log "Linting prompt files"
 npx prettier --write $pattern

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -72,8 +72,8 @@ Examples:
 Validation Types:
     dependencies          Verify memory-bank/dependencies.md structure
     markdown             Run markdownlint on all Markdown files
-    instructions         Validate .github/instructions/*.instructions.md
-    prompts              Validate .github/prompts/*.prompt.md
+    instructions         Validate memory-bank/instructions/*.instructions.md
+    prompts              Validate memory-bank/prompts/*.prompt.md
     tests                Run test suite and check coverage
     memory-bank          Validate memory bank file structure
 
@@ -132,7 +132,7 @@ check_markdown() {
 check_instructions() {
   log "Validating instruction files..."
 
-  INSTRUCTIONS_DIR="$PROJECT_ROOT/.github/instructions"
+  INSTRUCTIONS_DIR="$PROJECT_ROOT/memory-bank/instructions"
   if [ ! -d "$INSTRUCTIONS_DIR" ]; then
     warn "Instructions directory not found: $INSTRUCTIONS_DIR"
     return 0
@@ -183,7 +183,7 @@ check_instructions() {
 check_prompts() {
   log "Validating prompt files..."
 
-  PROMPTS_DIR="$PROJECT_ROOT/.github/prompts"
+  PROMPTS_DIR="$PROJECT_ROOT/memory-bank/prompts"
   if [ ! -d "$PROMPTS_DIR" ]; then
     warn "Prompts directory not found: $PROMPTS_DIR"
     return 0


### PR DESCRIPTION
## Summary
- reference `memory-bank` folders for instructions and prompts
- update validation scripts to new locations
- fix references in Copilot instructions and README
- adjust scripts and notebooks for updated paths

## Testing
- `./scripts/verify-all.sh --check markdown`

------
https://chatgpt.com/codex/tasks/task_e_6889724c40048331b7f710035d95d98f