### PR TITLE
Fix README counts and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ This workspace supports three AI agents with sophisticated collaboration pattern
 
 - **🧠 Cline AI** → [`.clinerules/main-rules.md`](.clinerules/main-rules.md) - Advanced development agent with memory bank integration
 - **⚡ Codex CLI** → [`AGENTS.md`](AGENTS.md) - Terminal-based automation and container orchestration
-- **💡 VS Code Copilot** → [`.github/copilot-instructions.md`](.github/copilot-instructions.md) - Code generation with 26 instruction files
+- **💡 VS Code Copilot** → [`.github/copilot-instructions.md`](.github/copilot-instructions.md) - Code generation with 31 instruction files
 
 ### AI Framework Components
 
-- **🔧 26 Instruction Files** ([`memory-bank/instructions/`](memory-bank/instructions/)) - Automated coding standards and guidelines
-- **⚙️ 27 Prompt Files** ([`memory-bank/prompts/`](memory-bank/prompts/)) - Executable workflow templates
+- **🔧 31 Instruction Files** ([`memory-bank/instructions/`](memory-bank/instructions/)) - Automated coding standards and guidelines
+- **⚙️ 35 Prompt Files** ([`memory-bank/prompts/`](memory-bank/prompts/)) - Executable workflow templates
 - **📚 Memory Bank System** ([`memory-bank/`](memory-bank/)) - Stateful documentation for AI collaboration
 - **🎯 Self-Documentation Protocol** - Maintains context across development sessions
 
@@ -221,7 +221,7 @@ npm run test:coverage
 
 ## 📚 Documentation System
 
-### Instruction Files (26 Files)
+### Instruction Files (31 Files)
 
 Automated coding standards that apply during AI-assisted development:
 
@@ -231,7 +231,7 @@ Automated coding standards that apply during AI-assisted development:
 - **Web Standards**: pwa-manifest, ios-meta-and-links, windows-tiles, theme-ui-meta
 - **Quality**: validation-debugging-checklist, self-documentation
 
-### Prompt Files (27 Files)
+### Prompt Files (35 Files)
 
 Executable workflow templates for automated development:
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,25 +1,26 @@
-   **Current State:**
-   The canonical playground `src/example.ts` was hardened to include HTTP status codes in the output file `.keys/example-sdk-demo.json` on error. The playground was built and executed, and the output file was verified to contain the correct status code (400) on failure. This confirms robust error reporting and output verification as part of the recursive demonstration workflow.
-   **Last Action:**
-   Patched `example.ts` to propagate and record HTTP status codes on error, rebuilt and ran the playground, and verified `.keys/example-sdk-demo.json` for correct error code output.
-   **Rationale:**
-   To fulfill the requirement for robust, agentic, and reproducible playground development, ensuring all error outputs include HTTP status codes for better debugging and agent memory.
-   **Next Intent:**
-   Continue recursive, output-verified workflow for all future playground iterations and maintain robust error reporting.
-   **Meta:**
-   I am updating my self-documentation after verifying output and HTTP error code inclusion. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+**Current State:**
+The canonical playground `src/example.ts` was hardened to include HTTP status codes in the output file `.keys/example-sdk-demo.json` on error. The playground was built and executed, and the output file was verified to contain the correct status code (400) on failure. This confirms robust error reporting and output verification as part of the recursive demonstration workflow.
+**Last Action:**
+Patched `example.ts` to propagate and record HTTP status codes on error, rebuilt and ran the playground, and verified `.keys/example-sdk-demo.json` for correct error code output.
+**Rationale:**
+To fulfill the requirement for robust, agentic, and reproducible playground development, ensuring all error outputs include HTTP status codes for better debugging and agent memory.
+**Next Intent:**
+Continue recursive, output-verified workflow for all future playground iterations and maintain robust error reporting.
+**Meta:**
+I am updating my self-documentation after verifying output and HTTP error code inclusion. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
 
- - [2025-07-29T20:30:00Z] Meta-Context Review and Validation of Operational Rules
-    **Current State:**
-    All meta-level operational rules, initialization protocols, and agent collaboration standards are codified and up to date. The CRITICAL MEMORY BANK PROTOCOL, agent obligations, recursive workflow patterns, and documentation standards are enforced across `.github/copilot-instructions.md` and memory-bank files. The three-agent system is fully described, and all meta-level standards (script-driven setup, idempotency, documentation, cross-agent compatibility, markdown-lint compliance) are actionable. Initialization, dependency/tooling detection, and environment readiness are referenced and described in the memory bank.
-    **Last Action:**
-    Reviewed and validated all meta-level operational rules, initialization, and agent protocols. Confirmed that all agents and contributors have clear, actionable guidance for high-level operations. No missing documentation or unclear rules found at the meta level.
-    **Rationale:**
-    To ensure the project’s meta-configuration, agent protocols, and operational rules are robust, actionable, and up to date, supporting effective multi-agent collaboration and stateful development.
-    **Next Intent:**
-    Continue to monitor and optimize meta-level documentation and operational rules as the project evolves. Update memory bank and documentation immediately upon any change in meta-configuration or agent protocols.
-    **Meta:**
-    I am updating my self-documentation after completing a meta-context review and validation. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+- [2025-07-29T20:30:00Z] Meta-Context Review and Validation of Operational Rules
+  **Current State:**
+  All meta-level operational rules, initialization protocols, and agent collaboration standards are codified and up to date. The CRITICAL MEMORY BANK PROTOCOL, agent obligations, recursive workflow patterns, and documentation standards are enforced across `.github/copilot-instructions.md` and memory-bank files. The three-agent system is fully described, and all meta-level standards (script-driven setup, idempotency, documentation, cross-agent compatibility, markdown-lint compliance) are actionable. Initialization, dependency/tooling detection, and environment readiness are referenced and described in the memory bank.
+  **Last Action:**
+  Reviewed and validated all meta-level operational rules, initialization, and agent protocols. Confirmed that all agents and contributors have clear, actionable guidance for high-level operations. No missing documentation or unclear rules found at the meta level.
+  **Rationale:**
+  To ensure the project’s meta-configuration, agent protocols, and operational rules are robust, actionable, and up to date, supporting effective multi-agent collaboration and stateful development.
+  **Next Intent:**
+  Continue to monitor and optimize meta-level documentation and operational rules as the project evolves. Update memory bank and documentation immediately upon any change in meta-configuration or agent protocols.
+  **Meta:**
+  I am updating my self-documentation after completing a meta-context review and validation. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+
 # The `activeContext.md` Memory Bank File
 
 As an AI Agent, you MUST actively strive to keep this file up to date with the latest active context, including project goals, user experience requirements, and AI agent collaboration framework. This file MUST be updated by any AI Agent accessing it, You MUST eagerly each time changes on each chat completion and each task or subtask as the living authoritative guide.
@@ -41,6 +42,7 @@ This file tracks the current work focus, recent changes, next steps, and active 
 ---
 
 ## Current Work Focus
+
 [2025-07-29T17:35:00Z] Example Playground Output Verification and Recursive Procedure Logging
 
 **Current State:**
@@ -135,6 +137,7 @@ Generated a detailed implementation plan addressing user requirements, triggered
 
 **Last Action:**
 Created detailed implementation plan addressing user requirements:
+
 - ✅ **Script Consolidation Assessment** - Plan to reduce from 42 to 22-25 scripts (45-50% reduction)
 - ✅ **Documentation Standardization** - Complete README updates reflecting standardized formats
 - ✅ **Memory Bank Optimization** - Continued optimization with cross-referencing and dependency tracking
@@ -156,6 +159,7 @@ Successfully completed comprehensive annotation of all 42 scripts in the `script
 
 **Last Action:**
 Fixed critical formatting error and completed script annotation:
+
 - ✅ Corrected shebang placement to line 1 for all scripts (was incorrectly on line 12)
 - ✅ Applied standardized 10-line header block to all remaining scripts
 - ✅ Added validation status pragma on the last line of each script
@@ -177,6 +181,7 @@ Successfully consolidated 41 scripts into 22 scripts (46% reduction). Implemente
 
 **Last Action:**
 Completed full script consolidation implementation:
+
 - ✅ Enhanced `setup_python_env.sh` with inline consolidation of Docker modes
 - ✅ Enhanced `verify-all.sh` as master validation script with selective checking
 - ✅ Enhanced `setup_ts_sdk.sh` as master TypeScript/SDK setup with module selection
@@ -200,6 +205,7 @@ Root context directories fully documented in `README.md` and `projectbrief.md`.
 Introduced script documentation protocol in `systemPatterns.md` and `.clinerules`.
 
 **Next Intent:**
+
 - Ensure all shell scripts contain header comments and are listed in `scripts/README.md`.
 - Consolidate any duplicate scripts.
 
@@ -260,7 +266,7 @@ User requested initial project analysis to understand environment topology befor
 
 **Major Reorganization Completed**:
 
-**✅ Main Instructions File** (`memory-bank/instructions/use-conventional-commits.instructions.md`):
+**✅ Main Instructions File** (`memory-bank/instructions/conventional-commits-must-be-used.instructions.md`):
 
 - **Concise and Clear**: Essential information only, quick reference format
 - **100% Gitmoji Compliance**: Every example includes mandatory gitmoji
@@ -340,7 +346,6 @@ User requested initial project analysis to understand environment topology befor
 
 ## Recent Changes
 
-
 ### [2025-07-23] Root Context Classification and Script Protocol
 
 **Achievement**: Documented all top-level folders with root context identification and established autonomous script documentation rules.
@@ -348,12 +353,12 @@ User requested initial project analysis to understand environment topology befor
 - Updated README.md and memory bank with complete folder inventory
 - Added requirement to update `scripts/README.md` whenever scripts change
 - Clarified that each script must document its purpose and decision rationale
- 
+
 ### [2025-07-22] Root Context Inventory & Script Protocol Added
 
 **Achievement**: Documented all top-level directories and implemented a mandatory
 script documentation protocol. Updated `README.md`, `projectbrief.md`, `systemPatterns.md`, and `.clinerules` accordingly.
- 
+
 ### [2025-07-23] Root Context Documentation and Script Protocol ✅
 
 **Achievement**: Added comprehensive folder inventory with root context
@@ -521,10 +526,11 @@ This project supports three AI agents with specific entry points:
 ---
 
 **Self-Documentation Protocol**: This entry reaffirms that all actions and context changes must be documented and that this rule itself is part of the ongoing protocol.
+
 ### [2025-07-17T03:53:10Z] Demo component refactor and actions consolidation
+
 - Split demo-components.tsx into individual files under src/components/examples
 - Optimized post-list state initialization
 - Consolidated actions.ts to re-export from enhanced-actions
- 
-**Last Updated:** 2025-07-23T00:00:00Z | **Status:** Root Context Protocol Established | **Priority:** Documentation Sync
 
+**Last Updated:** 2025-07-23T00:00:00Z | **Status:** Root Context Protocol Established | **Priority:** Documentation Sync

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -120,16 +120,16 @@ This file documents the technologies, development setup, technical constraints, 
 ### Quick Start Environment
 
 ```bash
-# 1. Set OpenAI API key for container integration
+#1. Set OpenAI API key for container integration
 export OPENAI_API_KEY="your-api-key-here"
 
-# 2. Initialize complete development environment
+#2. Initialize complete development environment
 ./scripts/setup_codex_universal.sh
 
-# 3. Start Codex Universal environment
+#3. Start Codex Universal environment
 ./scripts/codex_start.sh
 
-# 4. Access development shell
+#4. Access development shell
 ./scripts/codex_shell.sh
 ```
 
@@ -276,7 +276,6 @@ This project supports three AI agents with specific technical responsibilities:
 - **VS Code Copilot** → Enforce technical standards through instruction files and real-time code assistance
 
 **All agents must validate their technical implementations against the standards defined in this file and ensure compliance with established technical constraints.**
-
 
 [2025-07-27] Radical Documentation Reorganization: Migration Within Memory Bank
 


### PR DESCRIPTION
## Summary
- update counts for instruction and prompt files in README
- update headings for documentation sections
- adjust quick start numbering in techContext
- fix instructions file path in activeContext

## Testing
- `npx -y markdownlint-cli2 README.md memory-bank/techContext.md memory-bank/activeContext.md` *(fails: First line heading, MD041, and other lint errors)*
- `./scripts/verify-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68897e6fbff48331b14ac055a8744bfd