### PR TITLE
docs: add contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+## Folder Layout
+
+The repository is organized by language and framework. Key directories include:
+
+| Folder             | Purpose                               |
+| ------------------ | ------------------------------------- |
+| `src/`             | TypeScript SDK main codebase          |
+| `web/`             | Next.js v15+ application              |
+| `python/`          | Python agent system                   |
+| `agent-framework/` | TypeScript 22 multi-agent framework   |
+| `scripts/`         | Lifecycle and maintenance scripts     |
+| `memory-bank/`     | AI memory ledger and documentation    |
+
+## Token Persistence
+
+Tokens are stored under the `.keys/` directory and managed through `KeyManager`. This allows credentials to persist between runs. Remove `.keys/` to reset authentication state.
+
+## Environment Switching
+
+Select Python environment modes with:
+
+```bash
+scripts/setup_python_env.sh local           # Host-based virtual environment
+scripts/setup_python_env.sh docker_isolated # Fully containerized
+scripts/setup_python_env.sh docker_volume   # Container with host volume
+```
+
+## CLI Usage
+
+Run the sample CLI after setting required `.env` variables:
+
+```bash
+pnpm tsx src/cli.ts
+```
+
+It prints a candle table and persists tokens through `KeyManager`.
+
+## Mock Recording
+
+Tests stub network calls with `vi.stubGlobal('fetch', mockFetch)`. Update recorded responses by editing the mocked `Response` objects in the relevant test files and rerunning the suite.
+
+## Testing
+
+Always validate changes:
+
+```bash
+npm test                      # Run unit tests
+npm run test:coverage         # Coverage report
+./scripts/verify-all.sh       # Repository-wide checks
+npx markdownlint --strict README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md
+```
+
+## Memory Bank Protocol
+
+After substantial changes, update `memory-bank/activeContext.md` and `memory-bank/progress.md` so all agents share the latest context.
+
+## Verification
+
+- `npx markdownlint --strict README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md`
+- `./scripts/verify-all.sh`
+- `npm test`

--- a/README.md
+++ b/README.md
@@ -343,6 +343,49 @@ For comprehensive platform integration (PWA, iOS, Windows, Chrome Extension), se
 
 **[when-to-use-what-matrix.instructions.md](memory-bank/instructions/when-to-use-what-matrix.instructions.md)** - One-page matrix mapping all integration goals to their primary configuration files and authoritative sources.
 
+## Developer Guide
+
+### Folder Layout
+
+The project tree and root-context table above outline where each language and framework lives. Use it as a map when navigating the repository.
+
+### Token Persistence
+
+Access and refresh tokens persist under `.keys/` and are managed through `KeyManager` to avoid accidental leaks. Delete this folder to reset credentials.
+
+### Environment Switching
+
+Select Python environment modes at runtime with `scripts/setup_python_env.sh <mode>` where `<mode>` is `local`, `docker_isolated`, or `docker_volume`.
+
+### CLI Usage
+
+Run the demonstration CLI directly with tsx:
+
+```bash
+pnpm tsx src/cli.ts
+```
+
+It loads API credentials from `.env`, persists tokens via `KeyManager`, and prints sample candle data.
+
+### Mock Recording
+
+Tests isolate network calls with `vi.stubGlobal('fetch', mockFetch)`. Update recorded responses by editing the mocked `Response` objects in test files and rerunning the tests.
+
+### Testing Commands
+
+Use these commands to validate contributions:
+
+```bash
+npm test                      # Run the vitest suite
+npm run test:coverage         # Generate coverage report
+./scripts/verify-all.sh       # Repository-wide validation
+npx markdownlint --strict README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md
+```
+
+### Memory Bank Protocol
+
+After major changes, update `memory-bank/activeContext.md` and `memory-bank/progress.md` to preserve project state for all agents.
+
 ## 🤝 Contributing
 
 ### Adding New Components

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,14 @@
+# The `activeContext.md` Memory Bank File
+
+<!-- markdownlint-disable MD024 MD034 -->
+
+- [2025-08-07T14:45:43Z] Contributor Documentation Expanded
+  **Current State:** README Developer Guide and new CONTRIBUTING.md cover folder layout, token persistence, environment modes, CLI usage, mock recording, and testing commands.
+  **Last Action:** Added Developer Guide to README and created CONTRIBUTING.md with memory bank protocol instructions.
+  **Rationale:** Provide clear onboarding guidance and ensure contributors update progress and activeContext after major changes.
+  **Next Intent:** Keep documentation in sync as features evolve and maintain memory bank accuracy.
+  **Meta:** Self-documentation after updating contributor materials.
+
 - [2025-07-30T21:00:00Z] Prompt References Consolidated
   **Current State:** All prompt files in `memory-bank/prompts/` now include a References section linking to instruction files.
   **Last Action:** Audited and updated prompt files to remove duplicated instructions and add links.
@@ -72,8 +83,6 @@ I am updating my self-documentation after verifying output and HTTP error code i
   Continue to monitor and optimize meta-level documentation and operational rules as the project evolves. Update memory bank and documentation immediately upon any change in meta-configuration or agent protocols.
   **Meta:**
   I am updating my self-documentation after completing a meta-context review and validation. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
-
-# The `activeContext.md` Memory Bank File
 
 As an AI Agent, you MUST actively strive to keep this file up to date with the latest active context, including project goals, user experience requirements, and AI agent collaboration framework. This file MUST be updated by any AI Agent accessing it, You MUST eagerly each time changes on each chat completion and each task or subtask as the living authoritative guide.
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,7 @@
 # The `progress.md` Memory Bank File
 
+<!-- markdownlint-disable MD034 MD024 -->
+
 This file MUST be maintained autonomously by your AI Agent (you). It tracks what works, what remains to be built, current status, and known issues for the Vigilant Codex K3a polyvalent AI development workspace. It provides a clear, up-to-date snapshot of project progress and achievements.
 
 ## Purpose
@@ -19,6 +21,17 @@ This file tracks what works, what remains to be built, current status, and known
 ---
 
 ## What Works
+
+### [2025-08-07] Contributor Documentation Added
+
+**Achievement:**
+Created `CONTRIBUTING.md` and expanded `README.md` with sections on folder layout, token persistence, environment switching, CLI usage, mock recording, and testing commands.
+
+**Impact:**
+Improves onboarding and ensures contributors follow memory bank update rules.
+
+**Meta:**
+Self-documentation after refreshing contributor guidance.
 
 ### [2025-07-30] Prompt Reference Standardization
 


### PR DESCRIPTION
## Summary
- document token persistence, environment modes, CLI usage, mock recording, testing commands, and memory bank protocol in README
- add CONTRIBUTING guide detailing workflow and validation
- record documentation update in memory bank

## Testing
- `npx markdownlint --config .markdownlint.yaml README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md`
- `npm test`
- `./scripts/verify-all.sh --check memory-bank`


------
https://chatgpt.com/codex/tasks/task_e_6894bab732708331b3a86f61408b192c