### PR TITLE
docs: add development basics and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thank you for helping improve Vigilant Codex K3a. This guide summarizes core workflows and expectations for contributors.
+
+## Folder Layout
+
+The project is organized by root contexts: `src/` for the TypeScript SDK, `web/` for the Next.js app, `python/` for the agent system, and `agent-framework/` for the multi-agent framework. Additional folders like `scripts/`, `memory-bank/`, and `notebooks/` support automation and documentation.
+
+## Token Persistence
+
+Authentication tokens and example outputs live in the `.keys/` directory. The `KeyManager` handles saving and loading tokens so sessions can resume without re-authentication.
+
+## Environment Switching
+
+Python tooling supports three runtime modes. Choose one at setup time:
+
+```bash
+ENV_MODE=<local|docker_isolated|docker_volume> ./scripts/setup_python_env.sh
+```
+
+## CLI Usage
+
+Run common tasks through `pnpm` scripts or helper utilities in `scripts/`:
+
+```bash
+pnpm test:coverage
+pnpm run web:dev
+./scripts/verify-all.sh
+```
+
+## Mock Recording
+
+Use `src/example.ts` to capture deterministic API responses. Running the playground writes structured data to `.keys/example-sdk-demo.json`, which can serve as recorded mocks for tests and demos.
+
+## Testing Commands
+
+Validate changes before committing:
+
+```bash
+./scripts/verify-all.sh
+npm run test:coverage
+markdownlint --strict README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md
+```
+
+## Memory Bank Updates
+
+After significant changes, update `memory-bank/activeContext.md` and `memory-bank/progress.md` so the AI agents remain synchronized.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,52 @@ export OPENAI_API_KEY="your-api-key-here"
 ./scripts/setup_db_prisma.sh
 ```
 
+## 🧰 Development Basics
+
+### Folder Layout
+
+Code is organized by root context. The earlier directory table shows where TypeScript (`src/`), Next.js (`web/`), Python (`python/`), and other assets live. Use this structure to locate components and maintain clear boundaries between language ecosystems.
+
+### Token Persistence
+
+Authentication artifacts and playground outputs are stored in `.keys/`. The `KeyManager` ensures tokens and demo results persist across runs so agents can resume work without re-authentication.
+
+### Environment Switching
+
+Python tooling supports three modes—`local`, `docker_isolated`, and `docker_volume`. Select a mode at runtime:
+
+```bash
+ENV_MODE=<mode> ./scripts/setup_python_env.sh
+```
+
+### CLI Usage
+
+Run project tasks through `pnpm` scripts or the utilities in `scripts/`. Examples:
+
+```bash
+pnpm test:coverage
+pnpm run web:dev
+./scripts/verify-all.sh
+```
+
+### Mock Recording
+
+Use the canonical playground `src/example.ts` to capture fresh API responses. Running the example writes structured output to `.keys/example-sdk-demo.json`, providing deterministic data for future tests and demonstrations.
+
+### Testing Commands
+
+Key validation commands include:
+
+```bash
+./scripts/verify-all.sh       # run full repository checks
+npm run test:coverage         # execute unit tests with coverage
+markdownlint --strict README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md
+```
+
+## 🧠 Memory Bank Protocol
+
+After significant code or documentation changes, update `memory-bank/activeContext.md` and `memory-bank/progress.md` so all AI agents maintain a synchronized view of the project.
+
 ## 🎯 Key Features & Achievements
 
 ### Advanced HTTP Client Architecture

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,10 +1,16 @@
+- [2025-08-07T14:45:40Z] Documentation Guidelines Expanded
+  **Current State:** README documents folder layout, token persistence, environment switching, CLI usage, mock recording, and testing commands. CONTRIBUTING.md created with the same guidance and reminders to update memory bank files.
+  **Last Action:** Added development basics to README, created CONTRIBUTING.md, and noted memory bank protocol.
+  **Rationale:** Provide clear onboarding instructions and reinforce synchronized documentation.
+  **Next Intent:** Keep README, CONTRIBUTING.md, and memory bank entries current as new workflows emerge.
+  **Meta:** Self-documentation after enhancing repository guidelines.
+
 - [2025-07-30T21:00:00Z] Prompt References Consolidated
   **Current State:** All prompt files in `memory-bank/prompts/` now include a References section linking to instruction files.
   **Last Action:** Audited and updated prompt files to remove duplicated instructions and add links.
   **Rationale:** Centralizes instruction guidance and reduces duplication.
   **Next Intent:** Maintain prompt-instruction linkage for new or revised prompts.
   **Meta:** Self-documentation after completing prompt reference audit.
-
 **Current State:**
 TypeScript coding standards were modularized into topic-specific instruction files and README references updated.
 **Last Action:**

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -20,6 +20,17 @@ This file tracks what works, what remains to be built, current status, and known
 
 ## What Works
 
+### [2025-08-07] Documentation Workflow Clarification
+
+**Achievement:**
+README now details folder layout, token persistence, environment switching, CLI usage, mock recording, and testing commands. A new CONTRIBUTING.md reinforces these practices and the requirement to update memory bank files.
+
+**Impact:**
+Streamlines onboarding and ensures contributors maintain synchronized project context.
+
+**Meta:**
+Self-documentation after enhancing repository guidelines.
+
 ### [2025-07-30] Prompt Reference Standardization
 
 **Achievement:**


### PR DESCRIPTION
## Summary
- document folder layout, token persistence, environment modes, CLI usage, mock recording, and testing commands in README
- add a CONTRIBUTING guide with matching development and memory bank practices
- log documentation update in activeContext and progress memory bank files

## Testing
- `npx markdownlint README.md CONTRIBUTING.md memory-bank/activeContext.md memory-bank/progress.md` (fails: MD041 first-line heading, MD024 duplicate heading, MD034 bare URL)
- `timeout 100s ./scripts/verify-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6894bab732708331b3a86f61408b192c