### PR TITLE
chore: scaffold VS Code tasks configuration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,4 +1,13 @@
 {
   "version": "2.0.0",
-  "tasks": []
+  "tasks": [
+    {
+      "label": "project-status",
+      "type": "shell",
+      "command": "echo initialisation en attente..."
+    },
+    { "label": "lint", "command": "echo lint en attente..." },
+    { "label": "test", "command": "echo tests en attente..." },
+    { "label": "build", "command": "echo build en attente..." }
+  ]
 }

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,14 @@
+- [2025-08-09T06:00:07Z] VS Code placeholder tasks defined
+  **Current State:**
+  `.vscode/tasks.json` now defines shell tasks for project-status, lint, test, and build.
+  **Last Action:**
+  Replaced the empty tasks array with placeholder echo commands for initialisation.
+  **Rationale:**
+  Provide baseline VS Code tasks to guide future automation workflows.
+  **Next Intent:**
+  Update these tasks with real commands once tooling is ready.
+  **Meta:**
+  Self-documentation after adding editor tasks to support future workflow automation.
 - [2025-08-03T22:55:00Z] Created and referenced 'Get Current Date/Time' task for timestamping
   **Current State:**
   A dedicated task for obtaining the current date/time in ISO 8601 format has been defined in `scripts/README.md`. All instructions now reference this task instead of the raw `date --iso-8601=seconds` command. The self-documentation and instruction-authoring standards have been updated accordingly.
@@ -72,39 +83,40 @@
 
 **Current State:**
 TypeScript coding standards were modularized into topic-specific instruction files and README references updated.
- - [2025-08-08T00:00:00Z] Local CI & Commit Guard Implemented / Remote CI Removed
+
+- [2025-08-08T00:00:00Z] Local CI & Commit Guard Implemented / Remote CI Removed
   **Current State:** Remote GitHub Actions CI workflow deleted to eliminate external run costs. Local validation stack now includes `local-ci.sh` (full pipeline), `commit-guard.sh` (hook gate), and `install-hooks.sh` (hook deployment). Package scripts augmented (`ci:local`, `hooks:install`, `commit:force`). Scripts README updated; hook override variables documented.
   **Last Action:** Removed `.github/workflows/ci.yml`, created new scripts, updated documentation and package.json, appended self-documentation entry.
   **Rationale:** Reduce CI expenditure to $0 by shifting validation locally while retaining quality enforcement before commit/push with auditable overrides.
   **Next Intent:** Monitor developer workflow friction; optionally add JSON summary artifact & performance timings; consider selective parallelization in `local-ci.sh` if needed.
   **Meta:** Executing Self-Documentation Protocol for CI cost elimination and guard introduction.
   This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
-  - [2025-08-08T17:54:46-04:00] Attempted deletion of `.github/workflows/ci.yml` did not persist (file still present after delete patch). Will re-attempt deletion ensuring proper patch application and verify absence via directory listing and search before marking remote CI fully removed.
-    **Current State:** Workflow file contents still readable; local guard system operational.
-    **Last Action:** Issued delete patch; file_search still returns path; listed directory confirms presence.
-    **Rationale:** Must eliminate any chance of remote CI runs to guarantee zero external cost.
-    **Next Intent:** Re-issue deletion with correct tool context or alternative method, then re-verify and proceed to update documentation if needed.
-    **Meta:** I am updating my self-documentation after a failed deletion attempt. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
-  - [2025-08-08T18:12:51-04:00] Second deletion attempt of `.github/workflows/ci.yml` still shows file present (neutralized content). Tool search and directory listing persistently list file.
-    **Current State:** File contains only deactivation notice; no actionable jobs; remote CI effectively inert but artifact remains.
-    **Last Action:** Re-issued delete patch, re-ran search and directory listing, confirmed persistence; logged timestamp.
-    **Rationale:** Maintain transparency; artifact neutralization prevents runs while investigating deletion persistence (possible tool indexing constraint).
-    **Next Intent:** If full removal remains blocked, proceed with rename strategy or leave inert file; confirm with user preference before further attempts.
-    **Meta:** Executing Self-Documentation Protocol after repeated deletion attempt persistence. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
-  - [2025-08-08T18:18:21-04:00] Successfully removed `.github/workflows/ci.yml` via terminal `rm -f` and verified absence (search returns none, directory empty).
-    **Current State:** Remote CI workflow fully removed; only local validation (hooks + local-ci.sh) remains.
-    **Last Action:** Executed terminal removal, listed directory, confirmed empty; ran file search with no results.
-    **Rationale:** Finalize elimination of external CI cost surface and align with zero-remote-CI directive.
-    **Next Intent:** Monitor for accidental reintroduction; optionally add a safeguard script or git hook to block new workflow additions unless approved.
-    **Meta:** Executing Self-Documentation Protocol after successful deletion. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
-**Last Action:**
-Split `typescript-standards.instructions.md` into dedicated files and updated documentation.
-**Rationale:**
-Improve clarity and maintainability of TypeScript guidelines.
-**Next Intent:**
-Ensure agents use the new instruction files and keep documentation in sync.
-**Meta:**
-Self-documentation after modularizing TypeScript instructions.
+- [2025-08-08T17:54:46-04:00] Attempted deletion of `.github/workflows/ci.yml` did not persist (file still present after delete patch). Will re-attempt deletion ensuring proper patch application and verify absence via directory listing and search before marking remote CI fully removed.
+  **Current State:** Workflow file contents still readable; local guard system operational.
+  **Last Action:** Issued delete patch; file_search still returns path; listed directory confirms presence.
+  **Rationale:** Must eliminate any chance of remote CI runs to guarantee zero external cost.
+  **Next Intent:** Re-issue deletion with correct tool context or alternative method, then re-verify and proceed to update documentation if needed.
+  **Meta:** I am updating my self-documentation after a failed deletion attempt. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+- [2025-08-08T18:12:51-04:00] Second deletion attempt of `.github/workflows/ci.yml` still shows file present (neutralized content). Tool search and directory listing persistently list file.
+  **Current State:** File contains only deactivation notice; no actionable jobs; remote CI effectively inert but artifact remains.
+  **Last Action:** Re-issued delete patch, re-ran search and directory listing, confirmed persistence; logged timestamp.
+  **Rationale:** Maintain transparency; artifact neutralization prevents runs while investigating deletion persistence (possible tool indexing constraint).
+  **Next Intent:** If full removal remains blocked, proceed with rename strategy or leave inert file; confirm with user preference before further attempts.
+  **Meta:** Executing Self-Documentation Protocol after repeated deletion attempt persistence. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+- [2025-08-08T18:18:21-04:00] Successfully removed `.github/workflows/ci.yml` via terminal `rm -f` and verified absence (search returns none, directory empty).
+  **Current State:** Remote CI workflow fully removed; only local validation (hooks + local-ci.sh) remains.
+  **Last Action:** Executed terminal removal, listed directory, confirmed empty; ran file search with no results.
+  **Rationale:** Finalize elimination of external CI cost surface and align with zero-remote-CI directive.
+  **Next Intent:** Monitor for accidental reintroduction; optionally add a safeguard script or git hook to block new workflow additions unless approved.
+  **Meta:** Executing Self-Documentation Protocol after successful deletion. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+  **Last Action:**
+  Split `typescript-standards.instructions.md` into dedicated files and updated documentation.
+  **Rationale:**
+  Improve clarity and maintainability of TypeScript guidelines.
+  **Next Intent:**
+  Ensure agents use the new instruction files and keep documentation in sync.
+  **Meta:**
+  Self-documentation after modularizing TypeScript instructions.
 
 **Current State:**
 Instruction files for commit messages and Python environment use short, direct sentences with "You" and include verification blocks.


### PR DESCRIPTION
## Summary
- add placeholder VS Code tasks for project status, lint, tests and build
- document the new tasks in memory bank active context

## Testing
- `bash ./scripts/commit-guard.sh --stage manual --fast` *(fails: markdown lint errors across repo)*
- `bash ./scripts/local-ci.sh --fast --skip lint --skip install`


------
https://chatgpt.com/codex/tasks/task_e_6896e365efc883319c6833cc43293ec6