### PR TITLE
docs: standardize chatmode front matter

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,14 @@
+- [2025-08-09T06:03:14+00:00] Chatmode front matter simplified
+  **Current State:**
+  All chatmode files now have only `description` and an empty `tools` array in their front matter, removing explicit `model` declarations.
+  **Last Action:**
+  Removed model lines and cleared tools arrays in `plan`, `vscode-helper`, `setup-context`, `proto-notebook`, `questrade-sdk-developer`, and `tsdoc-typedoc` chatmodes.
+  **Rationale:**
+  Standardizes chatmode configuration and prevents hardcoded model references.
+  **Next Intent:**
+  Monitor chatmode files for consistency with evolving project standards.
+  **Meta:**
+  Self-documentation after simplifying chatmode front matter.
 - [2025-08-03T22:55:00Z] Created and referenced 'Get Current Date/Time' task for timestamping
   **Current State:**
   A dedicated task for obtaining the current date/time in ISO 8601 format has been defined in `scripts/README.md`. All instructions now reference this task instead of the raw `date --iso-8601=seconds` command. The self-documentation and instruction-authoring standards have been updated accordingly.

--- a/memory-bank/chatmodes/plan.chatmode.md
+++ b/memory-bank/chatmodes/plan.chatmode.md
@@ -1,7 +1,6 @@
 ---
 description: Generate an implementation plan for new features or refactoring existing code.
-model: GPT-4.1
-tools: ['codebase', 'fetch', 'findTestFiles', 'githubRepo', 'search', 'usages', 'copilotCodingAgent', 'editFiles', 'extensions', 'vscodeAPI', 'terminalLastCommand']
+tools: []
 ---
 
 # Planning mode instructions

--- a/memory-bank/chatmodes/proto-notebook.chatmode.md
+++ b/memory-bank/chatmodes/proto-notebook.chatmode.md
@@ -1,16 +1,6 @@
 ---
 description: 'Comprehensive Jupyter notebook development, execution, and analysis specialist with advanced VS Code integration for data science workflows'
-tools:  [
-    'codebase-usages',
-    'notebook-guru',
-    'extensions',
-    'fetch',
-    'findTestFiles',
-    'runCommands',
-    'search',
-    'vscodeAPI',
-    'copilotCodingAgent',
-  ]
+tools: []
 ---
 
 # Edit Jupyter notebooks with AI in VS Code

--- a/memory-bank/chatmodes/questrade-sdk-developer.chatmode.md
+++ b/memory-bank/chatmodes/questrade-sdk-developer.chatmode.md
@@ -1,7 +1,6 @@
 ---
 description: 'Specialized for developing a Questrade API SDK.'
-model: GPT-4.1
-tools: ['codebase-usages', 'terminal-and-tasks', 'fetch', 'problems', 'search']
+tools: []
 ---
 
 # Questrade SDK Developer Mode

--- a/memory-bank/chatmodes/setup-context.chatmode.md
+++ b/memory-bank/chatmodes/setup-context.chatmode.md
@@ -1,7 +1,6 @@
 ---
 description: High Level Context VS Code development helper, workspace configuration, API, extensions and anything related to this project in vscode, the way to instruct ai agents, teh way to have this multimodal project optimize at a high level.
-model: GPT-4.1
-tools: ['codebase', 'editFiles', 'fetch', 'githubRepo', 'microsoft_docs_search', 'microsoft-docs', 'problems', 'runCommands', 'terminalLastCommand', 'runTasks', 'search', 'usages', 'vscodeAPI']
+tools: []
 ---
 
 # Project Setup Mode instructions

--- a/memory-bank/chatmodes/tsdoc-typedoc.chatmode.md
+++ b/memory-bank/chatmodes/tsdoc-typedoc.chatmode.md
@@ -1,7 +1,6 @@
 ---
 description: 'Expert Mode for TypeScript Documentation with TSDoc and TypeDoc'
-model: GPT-4.1
-tools: ['codebase-usages', 'editFiles', 'fetch', 'runCommands', 'search', 'vscodeAPI', 'copilotCodingAgent']
+tools: []
 ---
 
 # TypeScript Documentation Expert

--- a/memory-bank/chatmodes/vscode-helper.chatmode.md
+++ b/memory-bank/chatmodes/vscode-helper.chatmode.md
@@ -1,8 +1,6 @@
 ---
 description: VS Code development helper for extensions, workspace configuration, and API usage and anything related to this project in vscode.
-model: GPT-4.1
- tools: ['usages', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'vscodeAPI', 'problems', 'terminal-and-tasks', 'editFiles', 'search', 'runCommands', 'runTasks', 'microsoft-docs']
-
+tools: []
 ---
 
 # VS Code Development Helper

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -20,6 +20,17 @@ This file tracks what works, what remains to be built, current status, and known
 
 ## What Works
 
+### [2025-08-09] Chatmode Front Matter Standardization
+
+**Achievement:**
+Removed explicit model references and cleared tool lists in all chatmode files (`plan`, `vscode-helper`, `setup-context`, `proto-notebook`, `questrade-sdk-developer`, `tsdoc-typedoc`).
+
+**Impact:**
+Simplifies chatmode configuration and prevents hardcoded model selection.
+
+**Meta:**
+Self-documentation after standardizing chatmode front matter.
+
 ### [2025-07-30] Instruction Formatting Standardization (Partial)
 
 **Achievement:**


### PR DESCRIPTION
## Summary
- remove hardcoded model references from chatmode front matter
- document chatmode simplification in active context and progress logs

## Testing
- `pnpm lint` *(fails: markdownlint issues in existing files)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896e391e6c08331b8fe80f660c607d7