### PR TITLE
docs(prompts): standardize prompt front matter

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,10 @@
+- [2025-08-09T06:04:52+00:00] Prompt metadata standardized
+  **Current State:** All prompt files now use front matter with description and tools fields, and all `mode:` lines were removed.
+  **Last Action:** Added missing front matter and removed deprecated `mode` lines across memory-bank/prompts.
+  **Rationale:** Ensure consistent metadata and align prompts with current project standards.
+  **Next Intent:** Monitor future prompt additions for compliance.
+  **Meta:** I am updating my self-documentation after standardizing prompt metadata. This entry reaffirms that all actions and context changes MUST be documented and that this rule itself is part of the ongoing protocol.
+
 - [2025-08-03T22:55:00Z] Created and referenced 'Get Current Date/Time' task for timestamping
   **Current State:**
   A dedicated task for obtaining the current date/time in ISO 8601 format has been defined in `scripts/README.md`. All instructions now reference this task instead of the raw `date --iso-8601=seconds` command. The self-documentation and instruction-authoring standards have been updated accordingly.

--- a/memory-bank/prompts/ai-template-manager.prompt.md
+++ b/memory-bank/prompts/ai-template-manager.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate optimized prompt and instruction files following project standards'
+tools: []
 ---
-
 # AI Agent Template Manager
 
 I will help you generate well-structured prompt and instruction files for your AI agent framework. I'll determine the appropriate file type, content structure, and placement based on your requirements while maintaining strict markdown-lint compliance.
@@ -34,7 +33,6 @@ I will help you generate well-structured prompt and instruction files for your A
 
 ````markdown
 applyTo: "${input:applyTo:Glob pattern for scope (e.g., \*_/_.ts)}"
-mode: 'agent'
 description: 'Generate optimized prompt and instruction files following project standards'
 
 ## Purpose
@@ -85,7 +83,6 @@ name: string;
 
 ```markdown
 ---
-mode: '${input:mode:agent}'
 tools: [${input:tools:'codebase', 'terminalLastCommand'}]
 description: '${input:description:Perform a specific automated task}'
 ---

--- a/memory-bank/prompts/breaking-changes.prompt.md
+++ b/memory-bank/prompts/breaking-changes.prompt.md
@@ -1,3 +1,7 @@
+---
+description: 'Guide for documenting breaking changes in commits.'
+tools: []
+---
 # Breaking Changes Guide (Concise)
 
 ## Required Format

--- a/memory-bank/prompts/codex-universal-environment.prompt.md
+++ b/memory-bank/prompts/codex-universal-environment.prompt.md
@@ -1,7 +1,7 @@
-mode: 'agent'
-mode: 'agent'
+---
 description: 'Setup a universal environment for Codex agents.'
-
+tools: []
+---
 # Codex Universal Docker Environment Manager
 
 I will help you create, configure, and manage Docker environments using the codex-universal image with Node.js 22 and Python 3.13, following volume-based development practices and comprehensive documentation standards.

--- a/memory-bank/prompts/commit-examples.prompt.md
+++ b/memory-bank/prompts/commit-examples.prompt.md
@@ -1,3 +1,7 @@
+---
+description: 'Examples of conventional commit messages with gitmoji.'
+tools: []
+---
 # Commit Examples
 
 This prompt file contains comprehensive examples of conventional commit messages with gitmoji.

--- a/memory-bank/prompts/dependency-management.prompt.md
+++ b/memory-bank/prompts/dependency-management.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'terminalLastCommand', 'githubRepo']
 description: 'Track and update project dependencies with proper documentation'
+tools: ['codebase', 'terminalLastCommand', 'githubRepo']
 ---
-
 # Dependency Management and Documentation
 
 Your task is to help me manage and document dependencies in the Codex CLI project following our established standards and protocols.

--- a/memory-bank/prompts/docker-consolidated-template.prompt.md
+++ b/memory-bank/prompts/docker-consolidated-template.prompt.md
@@ -1,7 +1,7 @@
-mode: 'agent'
-mode: 'agent'
+---
 description: 'Generate a consolidated Docker Compose template.'
-
+tools: []
+---
 # Docker & Dev Container Workflow Template
 
 Your goal is to generate a complete Docker containerization setup following the consolidated four-phase approach with exotic patterns, security-first principles, and comprehensive documentation.

--- a/memory-bank/prompts/docker-exotic-generator.prompt.md
+++ b/memory-bank/prompts/docker-exotic-generator.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'editFiles', 'runInTerminal', 'search', 'usages']
 description: 'Generate advanced Docker configurations with exotic patterns and security-first approach'
+tools: ['codebase', 'editFiles', 'runInTerminal', 'search', 'usages']
 ---
-
 # Docker Exotic Configuration Generator
 
 ## Description

--- a/memory-bank/prompts/docker-generator.prompt.md
+++ b/memory-bank/prompts/docker-generator.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate Dockerfiles and Compose files.'
+tools: []
 ---
-
 # Docker Configuration Generator
 
 I will help you create parametrized Docker configurations (Dockerfiles and Compose files) optimized for different environments while following security and performance best practices.

--- a/memory-bank/prompts/docker-modular-workflow.prompt.md
+++ b/memory-bank/prompts/docker-modular-workflow.prompt.md
@@ -1,7 +1,7 @@
-mode: 'agent'
-mode: 'agent'
+---
 description: 'Generate a modular Docker Compose workflow.'
-
+tools: []
+---
 # Docker Modular Workflow Generator
 
 ## Description

--- a/memory-bank/prompts/edge-devtools-debugging.prompt.md
+++ b/memory-bank/prompts/edge-devtools-debugging.prompt.md
@@ -1,10 +1,8 @@
 ---
-mode: 'agent'
-model: 'gpt-4.1'
-tools: ['codebase', 'filesystem', 'terminal', 'vscodeAPI']
 description: 'Automated Microsoft Edge DevTools debugging setup and configuration workflow'
+tools: ['codebase', 'filesystem', 'terminal', 'vscodeAPI']
+model: 'gpt-4.1'
 ---
-
 # Microsoft Edge DevTools Debugging Workflow
 
 **Category**: Development Workflows

--- a/memory-bank/prompts/file-organization.prompt.md
+++ b/memory-bank/prompts/file-organization.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'editFiles', 'fetch', 'problems', 'runInTerminal', 'runTasks', 'search', 'usages']
 description: 'Comprehensive standards for file and directory organization, naming, documentation, and memory bank integration across the entire project.'
+tools: ['codebase', 'editFiles', 'fetch', 'problems', 'runInTerminal', 'runTasks', 'search', 'usages']
 ---
-
 # File Organization Standards
 
 ## Project Root Structure

--- a/memory-bank/prompts/general-icon-link-tags.prompt.md
+++ b/memory-bank/prompts/general-icon-link-tags.prompt.md
@@ -1,7 +1,7 @@
-mode: 'agent'
-mode: 'agent'
+---
 description: 'Generate icon and link tags for all platforms.'
-
+tools: []
+---
 # Add General Icon Link Tags
 
 **Prompt**

--- a/memory-bank/prompts/git-hooks-automation.prompt.md
+++ b/memory-bank/prompts/git-hooks-automation.prompt.md
@@ -1,3 +1,7 @@
+---
+description: 'Instructions for git hooks and commit automation.'
+tools: []
+---
 # Git Hooks and Automation
 
 This prompt file contains information about git hooks and automation for conventional commits.

--- a/memory-bank/prompts/gitmoji-complete-list.prompt.md
+++ b/memory-bank/prompts/gitmoji-complete-list.prompt.md
@@ -1,3 +1,7 @@
+---
+description: 'Reference list of all gitmoji codes.'
+tools: []
+---
 # Complete Gitmoji List
 
 This prompt file contains the complete list of gitmoji for conventional commits.

--- a/memory-bank/prompts/instruction-creation-v2.prompt.md
+++ b/memory-bank/prompts/instruction-creation-v2.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate .instructions.md files with improved structure.'
+tools: []
 ---
-
 # Generate \*.instructions.md File
 
 Your goal is to create a properly structured `.instructions.md` file based on explicit user requirements for coding standards, guidelines, or project rules.

--- a/memory-bank/prompts/instruction-creation.prompt.md
+++ b/memory-bank/prompts/instruction-creation.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate *.instructions.md files with proper structure and content'
+tools: []
 ---
-
 # Generate \*.instructions.md File
 
 Your goal is to create a properly structured `.instructions.md` file based on the user's requirements for coding standards, guidelines, or project rules.

--- a/memory-bank/prompts/instruction-generator.prompt.md
+++ b/memory-bank/prompts/instruction-generator.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase']
 description: 'Generate *.instructions.md files with proper structure and content based on coding standards requirements'
+tools: ['codebase']
 ---
-
 # Generate Instructions File
 
 Your goal is to create a properly structured `.instructions.md` file based on the user's requirements for coding standards, guidelines, or project rules.

--- a/memory-bank/prompts/iterative-self-autonomous-ai-agent.prompt.md
+++ b/memory-bank/prompts/iterative-self-autonomous-ai-agent.prompt.md
@@ -1,10 +1,8 @@
 ---
-mode: 'agent'
-model: GPT-4.1
-tools: ['codebase-usages', 'githubRepo', 'problems', 'terminal-and-tasks']
 description: 'Iterative agent for ${TASK_NAME} – autonomously refine until build, tests, and lint pass.'
+tools: ['codebase-usages', 'githubRepo', 'problems', 'terminal-and-tasks']
+model: GPT-4.1
 ---
-
 # Self-Optimizing Autonomous Task Iteration
 
 Implement **${TASK_NAME}** according to project standards and the acceptance test suite.

--- a/memory-bank/prompts/launch-browser-monitor.prompt.md
+++ b/memory-bank/prompts/launch-browser-monitor.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'openSimpleBrowser', 'terminalLastCommand']
 description: 'Launch browser and enable instrumentation for live error monitoring during development'
+tools: ['codebase', 'openSimpleBrowser', 'terminalLastCommand']
 ---
-
 # Launch Browser and Instrumentation for Development Error Monitoring
 
 ## Context

--- a/memory-bank/prompts/memory-bank-update.prompt.md
+++ b/memory-bank/prompts/memory-bank-update.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'terminalLastCommand']
 description: 'Update memory bank documentation with proper cross-references'
+tools: ['codebase', 'terminalLastCommand']
 ---
-
 # Memory Bank Documentation Update
 
 Your task is to help me update `memory-bank/` documentation following our established standards and protocols.

--- a/memory-bank/prompts/notebook-development-workflow.prompt.md
+++ b/memory-bank/prompts/notebook-development-workflow.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'editFiles', 'runCommands', 'search', 'usages', 'vscodeAPI', 'extensions', 'copilotCodingAgent']
 description: 'Comprehensive notebook development workflow automation with VS Code integration'
+tools: ['codebase', 'editFiles', 'runCommands', 'search', 'usages', 'vscodeAPI', 'extensions', 'copilotCodingAgent']
 ---
-
 # Notebook Development Workflow Automation
 
 I will help you create, optimize, and manage Jupyter notebooks with full VS Code integration, following your established project standards and leveraging extended VS Code capabilities.

--- a/memory-bank/prompts/python-environment-setup.prompt.md
+++ b/memory-bank/prompts/python-environment-setup.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'runCommands', 'search', 'searchResults', 'usages']
 description: 'Guide the user through Python environment setup with conditional workflows'
+tools: ['codebase', 'runCommands', 'search', 'searchResults', 'usages']
 ---
-
 # Python Environment Setup Prompt
 
 ## Context

--- a/memory-bank/prompts/readme-update-review.prompt.md
+++ b/memory-bank/prompts/readme-update-review.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Guide for updating and reviewing README files across all project folders.'
+tools: []
 ---
-
 # README Update and Review Prompt
 
 ## Step-by-Step Workflow

--- a/memory-bank/prompts/script-generator.prompt.md
+++ b/memory-bank/prompts/script-generator.prompt.md
@@ -1,7 +1,7 @@
-mode: 'agent'
-mode: 'agent'
+---
 description: 'Generate shell scripts for project automation.'
-
+tools: []
+---
 # Script Generator
 
 I will help you create resilient, reusable scripts for automating project tasks. These scripts will be idempotent, well-documented, and follow project coding standards.

--- a/memory-bank/prompts/self-documentation.prompt.md
+++ b/memory-bank/prompts/self-documentation.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Automate self-documentation protocol.'
+tools: []
 ---
-
 # Self-Documentation Execution
 
 Your goal is to log and reinforce every action or context change by appending a structured entry to the designated self-documentation log (e.g., `memory-bank/activeContext.md`), following the Self-Documentation Protocol.

--- a/memory-bank/prompts/seo-meta-tags.prompt.md
+++ b/memory-bank/prompts/seo-meta-tags.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Add essential SEO meta tags to an HTML document.'
+tools: []
 ---
-
 # Add Essential SEO Meta Tags
 
 **Prompt**

--- a/memory-bank/prompts/template-manager.prompt.md
+++ b/memory-bank/prompts/template-manager.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate and manage prompt/instruction templates.'
+tools: []
 ---
-
 # Master Template Manager
 
 You are the **Project Template Manager** - the intelligence layer that decides when, where, and how to create or update `.prompt.md` and `.instructions.md` files. For every user request, you will autonomously classify, locate, and manage these files following best practices.
@@ -71,7 +70,6 @@ applyTo: '{glob-pattern}' # e.g., "**/*.ts", "**/tests/**", "**"
 
 ```markdown
 ---
-mode: 'agent' # 'agent', 'ask', or 'edit'
 tools: ['codebase', 'terminal'] # Available tools for the workflow
 description: '{Brief, searchable summary of the prompt purpose}'
 ---

--- a/memory-bank/prompts/test-prompt.prompt.md
+++ b/memory-bank/prompts/test-prompt.prompt.md
@@ -1,9 +1,7 @@
-mode: 'ask'
-tools: []
-description: 'Test prompt to verify prompt files are working'
-
 ---
-
+description: 'Test prompt to verify prompt files are working'
+tools: []
+---
 # Test Prompt
 
 This is a test prompt to verify that prompt files are working correctly in VS Code with GitHub Copilot.

--- a/memory-bank/prompts/theme-ui-meta.prompt.md
+++ b/memory-bank/prompts/theme-ui-meta.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate theme UI meta tags for browser theming.'
+tools: []
 ---
-
 > **Prompt**
 > _“Add browser-UI theming meta tags: `theme-color` for light +#3367d6 and dark +#101010 (media
 > query), `color-scheme` “light dark”, Windows `msapplication-TileColor` #3367d6, and iOS

--- a/memory-bank/prompts/tsdoc-typedoc.prompt.md
+++ b/memory-bank/prompts/tsdoc-typedoc.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['search', 'editFiles', 'runCommands', 'codebase-usages']
 description: 'Generate comprehensive TSDoc comments and TypeDoc setup for a TypeScript module'
+tools: ['search', 'editFiles', 'runCommands', 'codebase-usages']
 ---
-
 # TSDoc and TypeDoc Prompt
 
 When provided with the TypeScript file `${file}`, perform these tasks:

--- a/memory-bank/prompts/typescript-component.prompt.md
+++ b/memory-bank/prompts/typescript-component.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Generate a TypeScript React component.'
+tools: []
 ---
-
 Your goal is to generate a ${input:componentType:Select component type (class|interface|function|module)} named ${input:componentName} following Codex CLI TypeScript standards.
 
 ## Requirements

--- a/memory-bank/prompts/use-tool_name.prompt.md
+++ b/memory-bank/prompts/use-tool_name.prompt.md
@@ -2,7 +2,6 @@
 description: Use the tool name in your response when applicable.
 tools: ['codebase', 'usages', 'think', 'problems', 'terminalSelection', 'terminalLastCommand', 'fetch', 'editFiles', 'search', 'runCommands']
 ---
-
 # Use this specific tool now
 
 Use this tool to think deeply about the user's request and organize your thoughts. This tool helps improve response quality by allowing the model to consider the request carefully, brainstorm solutions, and plan complex tasks. It's particularly useful for:

--- a/memory-bank/prompts/validation-debugging-checklist.prompt.md
+++ b/memory-bank/prompts/validation-debugging-checklist.prompt.md
@@ -1,8 +1,7 @@
 ---
-mode: 'agent'
 description: 'Validation and debugging checklist for web app meta and manifest, a VS Code–centric checklist for validating and debugging web app meta tags, manifests, icons, deep links, and SEO elements using built-in tools and CLI/CI workflows.'
+tools: []
 ---
-
 # VS Code-Native Validation & Debugging Checklist
 
 ## 1. Overview 🔗 `#overview`

--- a/memory-bank/prompts/vit-implementation.prompt.md
+++ b/memory-bank/prompts/vit-implementation.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase', 'terminalLastCommand']
 description: 'Generate a Vision Transformer (ViT) implementation with detailed documentation'
+tools: ['codebase', 'terminalLastCommand']
 ---
-
 # Vision Transformer (ViT) Implementation
 
 Your task is to help me create a complete Vision Transformer (ViT) implementation following our project's coding standards and documentation requirements.

--- a/memory-bank/prompts/web-project-structure.prompt.md
+++ b/memory-bank/prompts/web-project-structure.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: 'Canonical Next.js + Prisma folder structure and authoring standards for web/src/'
+tools: []
 ---
-
 # 🗂️ Next.js + Prisma Project Structure Prompt
 
 ## Overview

--- a/memory-bank/prompts/x-cards.prompt.md
+++ b/memory-bank/prompts/x-cards.prompt.md
@@ -1,9 +1,7 @@
 ---
-mode: 'agent'
-tools: ['codebase']
 description: 'Add or update X Cards meta tags in HTML head sections'
+tools: ['codebase']
 ---
-
 # Add X Cards Meta Tags
 
 ## Context


### PR DESCRIPTION
## Summary
- ensure every prompt defines description and tools front matter
- drop deprecated `mode` lines across all prompts
- record prompt metadata update in active context

## Testing
- `pnpm lint:markdown` *(fails: various markdownlint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896e38fb8108331b728130164585d54