### PR TITLE
feat: add remote rpc actor system

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,9 @@
+- [2025-08-31T06:55:17+00:00] Remote RPC actors baseline
+  **Current State:** Minimal RPC system added under src/rpc with worker-thread pool, HTTP/TCP transports, protocol types, config, docs, and tests.
+  **Last Action:** Implemented module, added unit and integration tests, updated docs and dependency tracking.
+  **Rationale:** Establish foundation for remote actor architecture over HTTP/TCP for future expansion.
+  **Next Intent:** Introduce logging, backpressure metrics, and authentication.
+  **Meta:** Self-documentation after creating remote actor baseline and adding ts-node dependency.
 - [2025-08-23T00:00:00Z] Tasks-First Policy Adopted for VS Code
   **Current State:** `.github/copilot-instructions.md` now codifies a Tasks-First Execution Policy. `.vscode/tasks.json` includes a stable `hello:world` task; ad-hoc duplicates removed.
   **Last Action:** Added Tasks-First section instructing agents to use `run_task`/`get_task_output` first and `create_and_run_task` when needed. Normalized tasks file to avoid confusion and ensure discoverability.

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -1,5 +1,7 @@
 - **example.ts** → **.keys/example-sdk-demo.json** (Why: Playground output must include HTTP status codes for robust error reporting)
   - Impact: Enables agentic error handling, debugging, and recursive output verification
+- **ts-node** → **RpcWorkerPool** (Why: Enable TypeScript worker execution for RPC worker threads)
+  - Impact: Allows worker pool to run TypeScript command modules without pre-compilation
 
 # The `dependencies.md` Memory Bank File
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -20,6 +20,14 @@ This file tracks what works, what remains to be built, current status, and known
 
 ## What Works
 
+### [2025-08-31] Remote RPC Actors Baseline
+
+Achievement: Added `src/rpc` module implementing JSON RPC protocol, worker-thread pool, actor registry, HTTP and TCP transports, configuration loader, documentation, and comprehensive tests.
+
+Impact: Establishes extensible foundation for remote actor dispatch and transport-agnostic RPC, enabling future features like logging, metrics, and authentication.
+
+Meta: Self-documentation after introducing remote actor system and associated dependency updates.
+
 ### [2025-08-29] Layer 3 Factory Instructions Complete
 
 Achievement: Created comprehensive Layer 3 factory instruction files for creating and managing instructions, chatmodes, and prompt files with consistent guardrails and validation.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.1",
     "vitest": "^3.2.4",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "ts-node": "^10.9.2"
   },
   "engines": {
     "node": ">=22",

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,3 +141,4 @@ export type { CandlesParams } from './infra/helpers/candles';
 export * from './core/errors';
 export * from './core/rateLimit';
 export * from './core/types';
+export * as rpc from './rpc';

--- a/src/rpc/README.md
+++ b/src/rpc/README.md
@@ -1,0 +1,54 @@
+# Remote RPC Actors
+
+Minimal remote actor system exposing commands over HTTP and TCP using a worker-thread pool.
+
+## Architecture
+
+- **Protocol**: JSON request/response with `{ id, method, params }` and `{ id, result | error }`.
+- **Runtime**: `RpcWorkerPool` executes registered commands across worker threads.
+- **Actors**: Named pools with random selection helper.
+- **Transports**: HTTP `POST /rpc` and newline-delimited TCP.
+- **Config**: Defaults merged with environment variables and CLI flags.
+
+## Usage
+
+```ts
+import { methods } from './commands/methods';
+import { RpcWorkerPool } from './runtime/worker-pool';
+import { createHttpServer } from './transport/http';
+
+const methodsPath = require.resolve('./commands/methods.ts');
+const pool = new RpcWorkerPool(2, methodsPath);
+const server = createHttpServer(pool, { bodyLimit: 1_000_000, timeout: 5_000 });
+server.listen(8080);
+```
+
+HTTP request example:
+
+```bash
+curl -X POST http://localhost:8080/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"1","method":"echo","params":["hi"]}'
+```
+
+TCP example:
+
+```bash
+echo '{"id":"1","method":"sum","params":[1,2]}' | nc localhost 9090
+```
+
+## Config Keys
+
+| Key | Env | CLI | Default |
+| --- | --- | --- | --- |
+| httpPort | RPC_HTTP_PORT | --httpPort | 8080 |
+| tcpPort | RPC_TCP_PORT | --tcpPort | 9090 |
+| poolSize | RPC_POOL_SIZE | --poolSize | 2 |
+| bodyLimit | RPC_BODY_LIMIT | --bodyLimit | 1000000 |
+| timeout | RPC_TIMEOUT | --timeout | 5000 |
+
+## Next Steps
+
+- Backpressure strategy and queue metrics.
+- Structured logging and metrics export.
+- Authentication and input validation.

--- a/src/rpc/commands/methods.ts
+++ b/src/rpc/commands/methods.ts
@@ -1,0 +1,11 @@
+export type Method = (...args: unknown[]) => unknown | Promise<unknown>;
+export type Methods = Record<string, Method>;
+
+export const methods: Methods = {
+  helloworld: () => 'hello world',
+  echo: (msg: unknown) => msg,
+  sum: (...args: unknown[]) => {
+    const [a, b] = args as [number, number];
+    return a + b;
+  },
+};

--- a/src/rpc/config/index.ts
+++ b/src/rpc/config/index.ts
@@ -1,0 +1,37 @@
+import process from 'node:process';
+
+export interface RpcConfig {
+  httpPort: number;
+  tcpPort: number;
+  poolSize: number;
+  bodyLimit: number;
+  timeout: number;
+}
+
+const defaults: RpcConfig = {
+  httpPort: 8080,
+  tcpPort: 9090,
+  poolSize: 2,
+  bodyLimit: 1_000_000,
+  timeout: 5_000,
+};
+
+export function loadConfig(argv: string[] = process.argv.slice(2)): RpcConfig {
+  const env = process.env;
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const part = argv[i];
+    if (part.startsWith('--')) {
+      const [key, value] = part.replace(/^--/, '').split('=');
+      if (value) args[key] = value;
+      else if (argv[i + 1]) args[key] = argv[++i];
+    }
+  }
+  return {
+    httpPort: Number(args.httpPort ?? env.RPC_HTTP_PORT ?? defaults.httpPort),
+    tcpPort: Number(args.tcpPort ?? env.RPC_TCP_PORT ?? defaults.tcpPort),
+    poolSize: Number(args.poolSize ?? env.RPC_POOL_SIZE ?? defaults.poolSize),
+    bodyLimit: Number(args.bodyLimit ?? env.RPC_BODY_LIMIT ?? defaults.bodyLimit),
+    timeout: Number(args.timeout ?? env.RPC_TIMEOUT ?? defaults.timeout),
+  };
+}

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,0 +1,7 @@
+export * from './protocol';
+export * from './commands/methods';
+export * from './runtime/worker-pool';
+export * from './runtime/actors';
+export * from './transport/http';
+export * from './transport/tcp';
+export * from './config';

--- a/src/rpc/protocol/index.ts
+++ b/src/rpc/protocol/index.ts
@@ -1,0 +1,29 @@
+export interface RpcRequest {
+  id: string;
+  method: string;
+  params: unknown[];
+}
+
+export interface RpcResult {
+  id: string;
+  result: unknown;
+}
+
+export interface RpcError {
+  id: string;
+  error: { code: number; message: string; data?: unknown };
+}
+
+export type RpcResponse = RpcResult | RpcError;
+
+export const encodeRequest = (req: RpcRequest): string =>
+  JSON.stringify(req);
+
+export const decodeRequest = (payload: string): RpcRequest =>
+  JSON.parse(payload) as RpcRequest;
+
+export const encodeResponse = (res: RpcResponse): string =>
+  JSON.stringify(res);
+
+export const decodeResponse = (payload: string): RpcResponse =>
+  JSON.parse(payload) as RpcResponse;

--- a/src/rpc/runtime/actors.ts
+++ b/src/rpc/runtime/actors.ts
@@ -1,0 +1,33 @@
+import { RpcWorkerPool } from './worker-pool';
+
+export type ActorRegistry = Record<string, RpcWorkerPool>;
+
+export function initializeActors(
+  methodsPath: string,
+  poolSize: number,
+  names: string[],
+): ActorRegistry {
+  const registry: ActorRegistry = {};
+  for (const name of names) {
+    registry[name] = new RpcWorkerPool(poolSize, methodsPath);
+  }
+  return registry;
+}
+
+export function selectActor(
+  registry: ActorRegistry,
+  name?: string,
+): RpcWorkerPool {
+  const keys = Object.keys(registry);
+  if (name && registry[name]) return registry[name];
+  const key = keys[Math.floor(Math.random() * keys.length)];
+  return registry[key];
+}
+
+export function dispatch(
+  actor: RpcWorkerPool,
+  method: string,
+  params: unknown[],
+): Promise<unknown> {
+  return actor.exec(method, params);
+}

--- a/src/rpc/runtime/worker-pool.ts
+++ b/src/rpc/runtime/worker-pool.ts
@@ -1,0 +1,46 @@
+import { Worker } from 'node:worker_threads';
+import path from 'node:path';
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+export class RpcWorkerPool {
+  private workers: Worker[] = [];
+  private callbacks = new Map<number, Pending>();
+  private counter = 0;
+  private next = 0;
+
+  constructor(size: number, methodsPath: string) {
+    const workerFile = path.resolve(__dirname, 'worker.ts');
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(workerFile, {
+        execArgv: ['-r', 'ts-node/register'],
+        workerData: { methodsPath },
+      });
+      worker.on('message', (msg) => {
+        const cb = this.callbacks.get(msg.id);
+        if (!cb) return;
+        this.callbacks.delete(msg.id);
+        if (msg.error) cb.reject(new Error(msg.error.message));
+        else cb.resolve(msg.result);
+      });
+      this.workers.push(worker);
+    }
+  }
+
+  exec(method: string, params: unknown[]): Promise<unknown> {
+    const id = this.counter++;
+    return new Promise((resolve, reject) => {
+      this.callbacks.set(id, { resolve, reject });
+      const worker = this.workers[this.next];
+      this.next = (this.next + 1) % this.workers.length;
+      worker.postMessage({ id, method, params });
+    });
+  }
+
+  async destroy(): Promise<void> {
+    await Promise.all(this.workers.map((w) => w.terminate()));
+  }
+}

--- a/src/rpc/runtime/worker.ts
+++ b/src/rpc/runtime/worker.ts
@@ -1,0 +1,21 @@
+import { parentPort, workerData } from 'node:worker_threads';
+
+type Methods = Record<string, (...args: unknown[]) => unknown>;
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const imported = require(workerData.methodsPath) as {
+  methods?: Methods;
+} & Methods;
+const methods: Methods = imported.methods ?? imported;
+
+parentPort?.on('message', async ({ id, method, params }) => {
+  try {
+    const result = await methods[method](...(params as unknown[]));
+    parentPort?.postMessage({ id, result });
+  } catch (error) {
+    parentPort?.postMessage({
+      id,
+      error: { message: (error as Error).message },
+    });
+  }
+});

--- a/src/rpc/transport/http.ts
+++ b/src/rpc/transport/http.ts
@@ -1,0 +1,49 @@
+import http from 'node:http';
+import { RpcWorkerPool } from '../runtime/worker-pool';
+import { decodeRequest, encodeResponse } from '../protocol';
+
+interface HttpConfig {
+  bodyLimit: number;
+  timeout: number;
+}
+
+export function createHttpServer(
+  pool: RpcWorkerPool,
+  config: HttpConfig,
+): http.Server {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/rpc') {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > config.bodyLimit) {
+        res.statusCode = 413;
+        res.end();
+        req.destroy();
+      }
+    });
+    req.on('end', async () => {
+      try {
+        const rpcReq = decodeRequest(body);
+        const result = await pool.exec(rpcReq.method, rpcReq.params);
+        res.setHeader('Content-Type', 'application/json');
+        res.end(encodeResponse({ id: rpcReq.id, result }));
+      } catch (error) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          encodeResponse({
+            id: '0',
+            error: { code: 500, message: (error as Error).message },
+          }),
+        );
+      }
+    });
+  });
+  server.setTimeout(config.timeout);
+  return server;
+}

--- a/src/rpc/transport/tcp.ts
+++ b/src/rpc/transport/tcp.ts
@@ -1,0 +1,29 @@
+import net from 'node:net';
+import { RpcWorkerPool } from '../runtime/worker-pool';
+import { decodeRequest, encodeResponse } from '../protocol';
+
+export function createTcpServer(pool: RpcWorkerPool): net.Server {
+  return net.createServer((socket) => {
+    let buffer = '';
+    socket.on('data', async (chunk) => {
+      buffer += chunk.toString();
+      let index;
+      while ((index = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        try {
+          const req = decodeRequest(line);
+          const result = await pool.exec(req.method, req.params);
+          socket.write(encodeResponse({ id: req.id, result }) + '\n');
+        } catch (error) {
+          socket.write(
+            encodeResponse({
+              id: '0',
+              error: { code: 500, message: (error as Error).message },
+            }) + '\n',
+          );
+        }
+      }
+    });
+  });
+}

--- a/src/tests/rpc/actors.test.ts
+++ b/src/tests/rpc/actors.test.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import {
+  initializeActors,
+  selectActor,
+  dispatch,
+} from '../../rpc/runtime/actors';
+
+const methodsPath = path.resolve(__dirname, '../../rpc/commands/methods.ts');
+
+describe('actors', () => {
+  test('dispatch via random actor', async () => {
+    const actors = initializeActors(methodsPath, 1, ['a', 'b']);
+    const actor = selectActor(actors);
+    const result = await dispatch(actor, 'helloworld', []);
+    expect(result).toBe('hello world');
+    await Promise.all(Object.values(actors).map((a) => a.destroy()));
+  });
+});

--- a/src/tests/rpc/http.test.ts
+++ b/src/tests/rpc/http.test.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { RpcWorkerPool } from '../../rpc/runtime/worker-pool';
+import { createHttpServer } from '../../rpc/transport/http';
+import { encodeRequest, decodeResponse } from '../../rpc/protocol';
+
+describe('http transport', () => {
+  test('handles rpc request', async () => {
+    const methodsPath = path.resolve(__dirname, '../../rpc/commands/methods.ts');
+    const pool = new RpcWorkerPool(1, methodsPath);
+    const server = createHttpServer(pool, { bodyLimit: 1_000_000, timeout: 5_000 });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
+    const body = encodeRequest({ id: '1', method: 'sum', params: [2, 3] });
+    const res = await fetch(`http://127.0.0.1:${port}/rpc`, {
+      method: 'POST',
+      body,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const text = await res.text();
+    const rpcRes = decodeResponse(text);
+    expect(rpcRes).toEqual({ id: '1', result: 5 });
+    server.close();
+    await pool.destroy();
+  });
+});

--- a/src/tests/rpc/protocol.test.ts
+++ b/src/tests/rpc/protocol.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+import {
+  encodeRequest,
+  decodeRequest,
+  encodeResponse,
+  decodeResponse,
+  RpcRequest,
+  RpcResponse,
+} from '../../rpc/protocol';
+
+describe('protocol', () => {
+  test('request round trip', () => {
+    const req: RpcRequest = { id: '1', method: 'echo', params: ['hi'] };
+    const encoded = encodeRequest(req);
+    const decoded = decodeRequest(encoded);
+    expect(decoded).toEqual(req);
+  });
+
+  test('response round trip', () => {
+    const res: RpcResponse = { id: '1', result: 'ok' };
+    const encoded = encodeResponse(res);
+    const decoded = decodeResponse(encoded);
+    expect(decoded).toEqual(res);
+  });
+});

--- a/src/tests/rpc/tcp.test.ts
+++ b/src/tests/rpc/tcp.test.ts
@@ -1,0 +1,30 @@
+import net from 'node:net';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { RpcWorkerPool } from '../../rpc/runtime/worker-pool';
+import { createTcpServer } from '../../rpc/transport/tcp';
+import { encodeRequest, decodeResponse } from '../../rpc/protocol';
+
+describe('tcp transport', () => {
+  test('handles rpc request', async () => {
+    const methodsPath = path.resolve(__dirname, '../../rpc/commands/methods.ts');
+    const pool = new RpcWorkerPool(1, methodsPath);
+    const server = createTcpServer(pool);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
+
+    const client = net.createConnection(port);
+    const dataPromise = new Promise<string>((resolve) =>
+      client.once('data', (d) => resolve(d.toString())),
+    );
+    client.write(
+      encodeRequest({ id: '1', method: 'echo', params: ['hi'] }) + '\n',
+    );
+    const data = await dataPromise;
+    const rpcRes = decodeResponse(data.trim());
+    expect(rpcRes).toEqual({ id: '1', result: 'hi' });
+    client.end();
+    server.close();
+    await pool.destroy();
+  });
+});

--- a/src/tests/rpc/worker-pool.test.ts
+++ b/src/tests/rpc/worker-pool.test.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { RpcWorkerPool } from '../../rpc/runtime/worker-pool';
+
+describe('worker pool', () => {
+  test('executes methods', async () => {
+    const methodsPath = path.resolve(__dirname, '../../rpc/commands/methods.ts');
+    const pool = new RpcWorkerPool(2, methodsPath);
+    const result = await pool.exec('sum', [1, 2]);
+    expect(result).toBe(3);
+    await pool.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add JSON RPC protocol with request/response codecs
- implement worker-thread pool, actor registry, and HTTP/TCP transports
- document and test remote actor baseline, add ts-node dev dependency

## Testing
- `pnpm lint` *(fails: markdownlint issues in existing files)*
- `pnpm exec eslint 'src/rpc/**/*.ts'`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f0d86e0c8331b2b4ab2ea1743af9