### PR TITLE
feat: add remote actors rpc module

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,9 @@
+- [2025-08-31T06:53:41+00:00] Minimal remote actors RPC system added
+  **Current State:** Worker-thread pool, JSON protocol, HTTP/TCP transports, configuration, docs, and tests implemented under src/remote-actors.
+  **Last Action:** Added protocol codecs, method registry, worker pool with eval workers, actor dispatch, HTTP/TCP servers, configuration merger, documentation, and unit/integration tests.
+  **Rationale:** Establishes extensible baseline for remote actors framework within project context.
+  **Next Intent:** Add backpressure, error taxonomy, authentication, and typed client SDK.
+  **Meta:** Self-documentation after implementing remote actors MVP.
 - [2025-08-23T00:00:00Z] Tasks-First Policy Adopted for VS Code
   **Current State:** `.github/copilot-instructions.md` now codifies a Tasks-First Execution Policy. `.vscode/tasks.json` includes a stable `hello:world` task; ad-hoc duplicates removed.
   **Last Action:** Added Tasks-First section instructing agents to use `run_task`/`get_task_output` first and `create_and_run_task` when needed. Normalized tasks file to avoid confusion and ensure discoverability.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -19,6 +19,16 @@ This file tracks what works, what remains to be built, current status, and known
 ---
 
 ## What Works
+### [2025-08-31] Remote Actors RPC MVP
+
+Achievement: Implemented worker-thread-based RPC system with HTTP and TCP transports under `src/remote-actors`.
+
+Technical Implementation: Added JSON protocol codecs, method registry, worker pool using eval workers, actor dispatch API, HTTP/TCP servers, configuration merge, documentation, and unit/integration tests.
+
+Impact: Provides extensible baseline for remote actors enabling future features like backpressure, metrics, and typed clients.
+
+Meta: Self-documentation after delivering remote actors MVP.
+
 
 ### [2025-08-29] Layer 3 Factory Instructions Complete
 

--- a/src/remote-actors/README.md
+++ b/src/remote-actors/README.md
@@ -1,0 +1,49 @@
+# Remote Actors RPC System
+
+Minimal yet extensible RPC system supporting HTTP and TCP transports with worker-thread backed actors.
+
+## Features
+
+- JSON-based protocol with request/response envelopes
+- Worker-thread pool executing registered methods
+- HTTP and TCP servers dispatching to actor registry
+- Configurable via defaults, environment variables, and argv
+
+## Usage
+
+```ts
+import { methods, initializeActors, createHttpServer, createTcpServer, getConfig } from './remote-actors';
+
+const config = getConfig();
+const actor = initializeActors(methods, config.poolSize);
+createHttpServer(actor, { port: config.httpPort, maxBodySize: config.maxBodySize });
+createTcpServer(actor, { port: config.tcpPort });
+```
+
+### HTTP
+
+```bash
+curl -X POST http://localhost:3000/rpc -d '{"id":1,"method":"helloworld"}'
+```
+
+### TCP
+
+```bash
+echo '{"id":1,"method":"echo","params":"hi"}' | nc localhost 4000
+```
+
+## Configuration
+
+| Key | Env | Arg | Default |
+| --- | --- | --- | --- |
+| httpPort | RPC_HTTP_PORT | --httpPort | 3000 |
+| tcpPort | RPC_TCP_PORT | --tcpPort | 4000 |
+| poolSize | RPC_POOL_SIZE | --poolSize | 2 |
+| maxBodySize | RPC_MAX_BODY | --maxBodySize | 1048576 |
+
+## Next Steps
+
+- Backpressure and metrics
+- Structured error taxonomy
+- Auth and input validation
+- Typed client SDK

--- a/src/remote-actors/commands/methods.ts
+++ b/src/remote-actors/commands/methods.ts
@@ -1,0 +1,8 @@
+export type Method = (params: any) => Promise<any> | any;
+export type MethodRegistry = Record<string, Method>;
+
+export const methods: MethodRegistry = {
+  helloworld: () => 'hello world',
+  echo: (params) => params,
+  sum: (params: { a: number; b: number }) => params.a + params.b,
+};

--- a/src/remote-actors/config/index.ts
+++ b/src/remote-actors/config/index.ts
@@ -1,0 +1,52 @@
+export interface Config {
+  httpPort: number;
+  tcpPort: number;
+  poolSize: number;
+  maxBodySize: number;
+}
+
+const defaults: Config = {
+  httpPort: 3000,
+  tcpPort: 4000,
+  poolSize: 2,
+  maxBodySize: 1024 * 1024,
+};
+
+export function getEnvConfig(): Partial<Config> {
+  return {
+    httpPort: process.env.RPC_HTTP_PORT ? Number(process.env.RPC_HTTP_PORT) : undefined,
+    tcpPort: process.env.RPC_TCP_PORT ? Number(process.env.RPC_TCP_PORT) : undefined,
+    poolSize: process.env.RPC_POOL_SIZE ? Number(process.env.RPC_POOL_SIZE) : undefined,
+    maxBodySize: process.env.RPC_MAX_BODY ? Number(process.env.RPC_MAX_BODY) : undefined,
+  };
+}
+
+export function getArgvConfig(argv: string[]): Partial<Config> {
+  const cfg: Partial<Config> = {};
+  for (const arg of argv) {
+    const [key, value] = arg.split('=');
+    switch (key) {
+      case '--httpPort':
+        cfg.httpPort = Number(value);
+        break;
+      case '--tcpPort':
+        cfg.tcpPort = Number(value);
+        break;
+      case '--poolSize':
+        cfg.poolSize = Number(value);
+        break;
+      case '--maxBodySize':
+        cfg.maxBodySize = Number(value);
+        break;
+    }
+  }
+  return cfg;
+}
+
+export function getConfig(argv = process.argv.slice(2)): Config {
+  return {
+    ...defaults,
+    ...getEnvConfig(),
+    ...getArgvConfig(argv),
+  };
+}

--- a/src/remote-actors/index.ts
+++ b/src/remote-actors/index.ts
@@ -1,0 +1,7 @@
+export * from './protocol';
+export * from './commands/methods';
+export * from './runtime/workerPool';
+export * from './runtime/actors';
+export * from './transport/httpServer';
+export * from './transport/tcpServer';
+export * from './config';

--- a/src/remote-actors/protocol.ts
+++ b/src/remote-actors/protocol.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const RequestSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  method: z.string(),
+  params: z.any().optional(),
+});
+export type Request = z.infer<typeof RequestSchema>;
+
+export const SuccessSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  result: z.any(),
+});
+export const ErrorSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  error: z.object({
+    message: z.string(),
+  }),
+});
+export const ResponseSchema = z.union([SuccessSchema, ErrorSchema]);
+export type Response = z.infer<typeof ResponseSchema>;
+
+export function encodeRequest(req: Request): string {
+  return JSON.stringify(req);
+}
+
+export function decodeRequest(json: string): Request {
+  return RequestSchema.parse(JSON.parse(json));
+}
+
+export function encodeResponse(res: Response): string {
+  return JSON.stringify(res);
+}
+
+export function decodeResponse(json: string): Response {
+  return ResponseSchema.parse(JSON.parse(json));
+}

--- a/src/remote-actors/runtime/actors.ts
+++ b/src/remote-actors/runtime/actors.ts
@@ -1,0 +1,15 @@
+import { MethodRegistry } from '../commands/methods';
+import { RpcWorkerPool } from './workerPool';
+
+export interface Actor {
+  dispatch(method: string, params: any): Promise<any>;
+  close(): Promise<void>;
+}
+
+export function initializeActors(methods: MethodRegistry, size = 2): Actor {
+  const pool = new RpcWorkerPool(methods, size);
+  return {
+    dispatch: (method, params) => pool.exec(method, params),
+    close: () => pool.close(),
+  };
+}

--- a/src/remote-actors/runtime/workerPool.ts
+++ b/src/remote-actors/runtime/workerPool.ts
@@ -1,0 +1,72 @@
+import { Worker } from 'node:worker_threads';
+import { MethodRegistry } from '../commands/methods';
+import { Request, Response } from '../protocol';
+
+let nextId = 0;
+
+function serializeMethods(methods: MethodRegistry) {
+  const serialized: Record<string, string> = {};
+  for (const [name, fn] of Object.entries(methods)) {
+    serialized[name] = fn.toString();
+  }
+  return serialized;
+}
+
+function createWorker(methods: MethodRegistry): Worker {
+  const code = `
+    const { parentPort, workerData } = require('node:worker_threads');
+    const handlers = {};
+    for (const [name, src] of Object.entries(workerData.methods)) {
+      handlers[name] = eval(src);
+    }
+    parentPort.on('message', async (msg) => {
+      const { id, method, params } = msg;
+      try {
+        const result = await handlers[method](params);
+        parentPort.postMessage({ id, result });
+      } catch (err) {
+        parentPort.postMessage({ id, error: { message: err.message } });
+      }
+    });
+  `;
+  return new Worker(code, { eval: true, workerData: { methods: serializeMethods(methods) } });
+}
+
+export class RpcWorkerPool {
+  private workers: Worker[] = [];
+  private pending = new Map<number, (res: Response) => void>();
+  private index = 0;
+
+  constructor(private methods: MethodRegistry, private size = 2) {
+    for (let i = 0; i < size; i++) {
+      const worker = createWorker(methods);
+      worker.on('message', (res: Response) => {
+        const resolver = this.pending.get(res.id as number);
+        if (resolver) {
+          this.pending.delete(res.id as number);
+          resolver(res);
+        }
+      });
+      this.workers.push(worker);
+    }
+  }
+
+  exec(method: string, params: any): Promise<any> {
+    const id = nextId++;
+    const worker = this.workers[this.index++ % this.workers.length];
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, (res) => {
+        if ('error' in res) {
+          reject(new Error(res.error.message));
+        } else {
+          resolve(res.result);
+        }
+      });
+      worker.postMessage({ id, method, params } as Request);
+    });
+  }
+
+  async close(): Promise<void> {
+    await Promise.all(this.workers.map((w) => w.terminate()));
+  }
+}

--- a/src/remote-actors/transport/httpServer.ts
+++ b/src/remote-actors/transport/httpServer.ts
@@ -1,0 +1,52 @@
+import http from 'node:http';
+import { Actor } from '../runtime/actors';
+import { decodeRequest, encodeResponse } from '../protocol';
+
+export interface HttpConfig {
+  port: number;
+  maxBodySize: number;
+}
+
+export function createHttpServer(actor: Actor, config: HttpConfig) {
+  const server = http.createServer(async (req, res) => {
+    if (req.method !== 'POST' || req.url !== '/rpc') {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > config.maxBodySize) {
+        res.statusCode = 413;
+        res.end();
+        req.destroy();
+      } else {
+        chunks.push(chunk);
+      }
+    });
+
+    req.on('end', async () => {
+      try {
+        const body = Buffer.concat(chunks).toString();
+        const request = decodeRequest(body);
+        const result = await actor.dispatch(request.method, request.params);
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          encodeResponse({ id: request.id, result })
+        );
+      } catch (err) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          encodeResponse({ id: 0, error: { message: (err as Error).message } })
+        );
+      }
+    });
+  });
+
+  server.listen(config.port);
+  return server;
+}

--- a/src/remote-actors/transport/tcpServer.ts
+++ b/src/remote-actors/transport/tcpServer.ts
@@ -1,0 +1,34 @@
+import net from 'node:net';
+import { Actor } from '../runtime/actors';
+import { decodeRequest, encodeResponse } from '../protocol';
+
+export interface TcpConfig {
+  port: number;
+}
+
+export function createTcpServer(actor: Actor, config: TcpConfig) {
+  const server = net.createServer((socket) => {
+    let buffer = '';
+    socket.on('data', async (chunk) => {
+      buffer += chunk.toString();
+      let index;
+      while ((index = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        if (!line.trim()) continue;
+        try {
+          const req = decodeRequest(line);
+          const result = await actor.dispatch(req.method, req.params);
+          socket.write(encodeResponse({ id: req.id, result }) + '\n');
+        } catch (err) {
+          socket.write(
+            encodeResponse({ id: 0, error: { message: (err as Error).message } }) + '\n'
+          );
+        }
+      }
+    });
+  });
+
+  server.listen(config.port);
+  return server;
+}

--- a/src/tests/remote-actors/httpServer.test.ts
+++ b/src/tests/remote-actors/httpServer.test.ts
@@ -1,0 +1,23 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { methods, initializeActors, createHttpServer } from '../../remote-actors';
+
+const actor = initializeActors(methods, 2);
+const server = createHttpServer(actor, { port: 0, maxBodySize: 1024 });
+const address = server.address();
+const port = typeof address === 'object' && address ? address.port : 0;
+
+afterAll(async () => {
+  await actor.close();
+  server.close();
+});
+
+describe('http server', () => {
+  it('responds to rpc calls', async () => {
+    const res = await fetch(`http://localhost:${port}/rpc`, {
+      method: 'POST',
+      body: JSON.stringify({ id: 1, method: 'helloworld' }),
+    });
+    const json = await res.json();
+    expect(json).toEqual({ id: 1, result: 'hello world' });
+  });
+});

--- a/src/tests/remote-actors/protocol.test.ts
+++ b/src/tests/remote-actors/protocol.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { encodeRequest, decodeRequest, encodeResponse, decodeResponse } from '../../remote-actors';
+
+describe('protocol', () => {
+  it('round trips request', () => {
+    const req = { id: 1, method: 'echo', params: 'hi' };
+    const json = encodeRequest(req);
+    const parsed = decodeRequest(json);
+    expect(parsed).toEqual(req);
+  });
+
+  it('round trips response', () => {
+    const res = { id: 1, result: 'ok' };
+    const json = encodeResponse(res);
+    const parsed = decodeResponse(json);
+    expect(parsed).toEqual(res);
+  });
+});

--- a/src/tests/remote-actors/tcpServer.test.ts
+++ b/src/tests/remote-actors/tcpServer.test.ts
@@ -1,0 +1,28 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import net from 'node:net';
+import { methods, initializeActors, createTcpServer } from '../../remote-actors';
+
+const actor = initializeActors(methods, 2);
+const server = createTcpServer(actor, { port: 0 });
+const address = server.address();
+const port = typeof address === 'object' && address ? address.port : 0;
+
+afterAll(async () => {
+  await actor.close();
+  server.close();
+});
+
+describe('tcp server', () => {
+  it('responds to rpc calls', async () => {
+    const socket = net.connect(port); 
+    const promise = new Promise<string>((resolve) => {
+      socket.on('data', (data) => {
+        resolve(data.toString().trim());
+        socket.end();
+      });
+    });
+    socket.write('{"id":1,"method":"echo","params":"hi"}\n');
+    const response = await promise;
+    expect(response).toBe('{"id":1,"result":"hi"}');
+  });
+});

--- a/src/tests/remote-actors/workerPool.test.ts
+++ b/src/tests/remote-actors/workerPool.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, afterAll } from 'vitest';
+import { methods, RpcWorkerPool } from '../../remote-actors';
+
+describe('worker pool', () => {
+  const pool = new RpcWorkerPool(methods, 2);
+  afterAll(async () => {
+    await pool.close();
+  });
+
+  it('executes methods', async () => {
+    const res = await pool.exec('sum', { a: 2, b: 3 });
+    expect(res).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- implement JSON RPC protocol, worker-thread pool, actor registry, and transports
- add configuration merge utilities and sample method registry
- document remote actors module and record memory bank updates

## Testing
- `pnpm test src/tests/remote-actors/*.test.ts`
- `pnpm run lint` *(fails: markdownlint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f0d86e0c8331b2b4ab2ea1743af9