### PR TITLE
chore: consolidate prompt authoring workflow

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,10 @@
+- [2025-08-31T06:56:22+00:00] Canonical prompt workflow selected
+  **Current State:** `define-prompt-file.prompt.md` adopted as sole prompt-authoring workflow; `make-prompts.prompt.md` and `prompt-files.prompt.md` archived.
+  **Last Action:** Archived superseded prompt files and updated references.
+  **Rationale:** Consolidate prompt authoring to a single protocol and remove outdated guides.
+  **Next Intent:** Monitor future prompts for compliance.
+  **Meta:** Self-documentation after consolidating prompt authoring workflow.
+
 - [2025-08-23T00:00:00Z] Tasks-First Policy Adopted for VS Code
   **Current State:** `.github/copilot-instructions.md` now codifies a Tasks-First Execution Policy. `.vscode/tasks.json` includes a stable `hello:world` task; ad-hoc duplicates removed.
   **Last Action:** Added Tasks-First section instructing agents to use `run_task`/`get_task_output` first and `create_and_run_task` when needed. Normalized tasks file to avoid confusion and ensure discoverability.

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -12,7 +12,7 @@ This file tracks all project dependencies, their relationships, and integration 
 ### Script Management and Optimization Protocol
 
 - **34 instruction files** - Automated coding standards in `memory-bank/instructions/` (including Layer 3 factory instructions)
-- **35 prompt files** - Executable workflow templates in `memory-bank/prompts/`
+- **40 prompt files** - Executable workflow templates in `memory-bank/prompts/`
 
 ### Dependencies and Relationships
 
@@ -78,7 +78,7 @@ This file tracks all project dependencies, their relationships, and integration 
 - **Cline AI** - Primary development agent (`.clinerules/main-rules.md`)
 - **VS Code Copilot** - Code generation (`.github/copilot-instructions.md`)
   **31 instruction files** - Automated coding standards in `memory-bank/instructions/`
-  **35 prompt files** - Executable workflow templates in `memory-bank/prompts/`
+  **40 prompt files** - Executable workflow templates in `memory-bank/prompts/`
 
 > [!IMPORTANT]
 
@@ -110,7 +110,7 @@ This file tracks all project dependencies, their relationships, and integration 
 **Depends On:** tsconfig.json baseUrl and paths configuration, TypeScript standards from `memory-bank/instructions/`
 
 - **31 instruction files** - Automated coding standards in `memory-bank/instructions/`
-- **35 prompt files** - Executable workflow templates in `memory-bank/prompts/`
+- **40 prompt files** - Executable workflow templates in `memory-bank/prompts/`
   All agents must consult the [when-to-use-what-matrix.instructions.md](../memory-bank/instructions/when-to-use-what-matrix.instructions.md) for a one-page mapping of integration goals to configuration files and authoritative sources. For detailed implementation, see `memory-bank/instructions/README.md` and `memory-bank/prompts/README.md`.
 - **Conditional Architecture** - Runtime decision frameworks
 - **Parameter-Driven Configuration** - ENV_MODE and similar runtime selection
@@ -174,7 +174,7 @@ ENV_MODE Parameter Selection
 ### [2025-07-13] README Drift Resolution
 
 **Rationale:** Synchronized documentation between instruction files, prompt files, and main README to accurately represent workspace sophistication.
-**Technical Implementation:** Analysis of 31 instruction files and 35 prompt files, complete README reconstruction reflecting AI agent ecosystem.
+**Technical Implementation:** Analysis of 31 instruction files and 40 prompt files, complete README reconstruction reflecting AI agent ecosystem.
 **Impact:** Proper workspace representation for AI agents and developers.
 
 ### [2025-07-20] Native Fetch API Conversion

--- a/memory-bank/instructions/layer-4-automation-and-health.instructions.md
+++ b/memory-bank/instructions/layer-4-automation-and-health.instructions.md
@@ -91,7 +91,7 @@ Artifacts to Ensure
 
 - Ensure these repository-specific prompt cards exist (copy if missing; see Acquisition below):
   - `memory-bank/prompts/bootstrap-genesis.prompt.md`
-  - `memory-bank/prompts/prompt-files.prompt.md`
+  - `memory-bank/prompts/define-prompt-file.prompt.md`
 - Validate them with `scripts/validate-prompts.sh`.
 
 9. Prompt Contract Resilience
@@ -129,7 +129,7 @@ Acquisition (Copy From Source Context)
   - `memory-bank/instructions/gitmoji-complete-list.instructions.md`
 <!-- excluded rules for the time being they should have been covered by the agentic workflow you enacted and should not be overidded anyway this is excluded for the time being into a comment out ppath of actions:
   - `scripts/validate-memory-bank.sh`, `scripts/validate-chatmodes.sh`, `scripts/validate-prompts.sh`, `scripts/triad-health.sh`, `scripts/list-slash-commands.sh`
-  - `memory-bank/prompts/bootstrap-genesis.prompt.md`, `memory-bank/prompts/prompt-files.prompt.md`
+  - `memory-bank/prompts/bootstrap-genesis.prompt.md`, `memory-bank/prompts/define-prompt-file.prompt.md`
   - `.prettierignore`-->
 - Execution options:
   1. If operating inside this repository, copy from the relative paths above.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -20,6 +20,16 @@ This file tracks what works, what remains to be built, current status, and known
 
 ## What Works
 
+### [2025-08-31] Prompt authoring workflow consolidated
+
+Achievement: Adopted `define-prompt-file.prompt.md` as the single canonical prompt-authoring workflow and archived superseded guides.
+
+Technical Implementation: Moved `make-prompts.prompt.md` and `prompt-files.prompt.md` to `memory-bank/prompts/archives/`, updated references in documentation and instructions, and normalized the surviving prompt to repository standards.
+
+Impact: Removes conflicting guidance and establishes a unified lifecycle for `.prompt.md` files, improving maintainability and cross-file consistency.
+
+Meta: Self-documentation after consolidating prompt authoring.
+
 ### [2025-08-29] Layer 3 Factory Instructions Complete
 
 Achievement: Created comprehensive Layer 3 factory instruction files for creating and managing instructions, chatmodes, and prompt files with consistent guardrails and validation.

--- a/memory-bank/prompts/README.md
+++ b/memory-bank/prompts/README.md
@@ -19,7 +19,7 @@ Prompt files (`.prompt.md`) are executable templates that:
 - Include variables for customization and reusability
 - Use tools to perform actions like file creation, code generation, or terminal commands
 
-## Available Prompts (38 Files)
+## Available Prompts (40 Files)
 
 > **Note:** This list must be kept in sync with the actual prompt files in this directory. Add new prompts and update descriptions as needed.
 
@@ -30,7 +30,7 @@ Prompt files (`.prompt.md`) are executable templates that:
 - **[instruction-generator.prompt.md](./instruction-generator.prompt.md)** — Generate `.instructions.md` files with a focus on structure, standards, and detailed validation templates for coding requirements.
 - **[instruction-creation.prompt.md](./instruction-creation.prompt.md)** — Create `.instructions.md` files using a process-oriented, QA-driven approach, emphasizing validation, error prevention, and best practices.
 - **[instruction-creation-v2.prompt.md](./instruction-creation-v2.prompt.md)** — Enhanced instruction file creation with advanced validation.
-- **[make-prompts.prompt.md](./make-prompts.prompt.md)** — Project directives and guardrails for creating, validating, and maintaining `*.prompt.md` files and keeping README in sync.
+- **[define-prompt-file.prompt.md](./define-prompt-file.prompt.md)** — Protocol to author, audit, and maintain prompt cards.
 
 ### Environment & Infrastructure
 

--- a/memory-bank/prompts/archives/make-prompts.prompt.md
+++ b/memory-bank/prompts/archives/make-prompts.prompt.md
@@ -3,9 +3,12 @@ description: "Guidance for creating .prompt.md files in the VS Code project."
 tools: ['codebase', 'usages', 'fetch', 'problems', 'editFiles', 'runCommands', 'todos', 'runInTerminal', 'getTerminalOutput']
 ---
 
-<!-- memory-bank/prompts/make-prompts.prompt.md -->
+<!-- memory-bank/prompts/archives/make-prompts.prompt.md -->
 
-# Project Directives: 📜 VSCODE *.prompt.md Scribe 🖋️ 
+# Project Directives: 📜 VSCODE *.prompt.md Scribe 🖋️
+
+> [!NOTE]
+> Archived on 2025-08-31; replaced by [../define-prompt-file.prompt.md](../define-prompt-file.prompt.md).
 
 Directives for Vscode Copilot's `*.prompt.md` This governs how `.prompt.md` files are authored, reviewed, and delivered for consumption in vscode. Since vscode leverages gpt-5 as the new engine behind copilot you have been given a prompting cookbook style guidance which can help you when you are drafting such a prompt file as a general rule of thumb, when it is relevant and can be extended.
 

--- a/memory-bank/prompts/archives/prompt-files.prompt.md
+++ b/memory-bank/prompts/archives/prompt-files.prompt.md
@@ -2,9 +2,12 @@
 description: Author and run *.prompt.md cards under memory-bank/prompts/ with our strict format and guardrails.
 ---
 
-<!-- memory-bank/prompts/prompt-files-guide.prompt.md -->
+<!-- memory-bank/prompts/archives/prompt-files.prompt.md -->
 
 # Prompt Files Guide
+
+> [!NOTE]
+> Archived on 2025-08-31; replaced by [../define-prompt-file.prompt.md](../define-prompt-file.prompt.md).
 
 ## Slash Command: /prompt-files-guide - Author and run *.prompt.md cards
 

--- a/memory-bank/prompts/define-prompt-file.prompt.md
+++ b/memory-bank/prompts/define-prompt-file.prompt.md
@@ -1,210 +1,62 @@
 ---
-  description: Project-wide protocol to author, audit, refactor, migrate, and maintain compliant `.prompt.md` files in `memory-bank/prompts/`.
-  tools: ['codebase', 'problems', 'fetch', 'todos', 'editFiles', 'runCommands']
+description: Project-wide protocol to author, audit, refactor, migrate, and maintain compliant `.prompt.md` files in `memory-bank/prompts/`.
+tools: ['codebase', 'problems', 'fetch', 'todos', 'editFiles', 'runCommands']
 ---
-    
-  # description: Project-wide protocol to author, audit, refactor, migrate, and maintain compliant `.prompt.md` files in `memory-bank/prompts/`.
 
-  <!-- memory-bank/prompts/define-prompt-file.prompt.md -->
+<!-- memory-bank/prompts/define-prompt-file.prompt.md -->
 
-  ## Define Prompt File
+# Define Prompt File
+Establishes a single lifecycle procedure for creating, auditing, repairing, refactoring, migrating, and normalizing prompt cards.
 
-  > [!IMPORTANT]
-  > Slash command: /define-prompt-file used to call this prompt card please enact this prompt card when you see this file being referenced by the user or another prompt.
+> [!NOTE]
+> Supersedes [archives/make-prompts.prompt.md](./archives/make-prompts.prompt.md) and [archives/prompt-files.prompt.md](./archives/prompt-files.prompt.md).
 
-  ## Intent
+## Slash Command: /define-prompt-file - Manage `.prompt.md` lifecycle
+One authoritative workflow to keep prompt cards valid across creation and maintenance.
 
-  Provide one strict procedure for all lifecycle tasks on `.prompt.md` files: creation, review, repair, refactor, migration, normalization, and documentation. Filename work is a single validation step. Ensure reliability in VS Code, Copilot Chat, and related tooling.
+> [!IMPORTANT]
+> `/define-prompt-file` has been called by the user to manage `.prompt.md` files. The state above applies for this run.
 
-  ## Inputs
+### Context & Activation
+- **Scope:** `.prompt.md` files in `memory-bank/prompts/`
+- **State:** Normalize front matter, path comment, headers, and sections
+- **Inputs:** `${input:file}` path or raw instructions
+- **Safety:** Do nothing if the file already matches this protocol
 
-  * **Required:** Raw instructions or existing `.prompt.md` content.
-  * **Optional:** Existing front matter keys (`description`, `tools`, `mode`, `model`) to retain as-is.
+### Goal
+Produce a prompt file that fully complies with repository standards or report when already compliant.
 
-  ## Preconditions
+### Output format
+Return a corrected `.prompt.md` ready to commit, or an audit summary followed by the corrected file.
 
-  * Files reside under `memory-bank/prompts/`.
-  * Filenames are verb-first, lowercase kebab-case, ending with `.prompt.md`.
-  * This protocol overrides other conventions.
+### Inputs
+- `${input:file}` (optional) target file path
+- `${selection}` (optional) existing prompt content
+- `${input:raw}` (optional) instructions to transform into a prompt card
 
-  ## Steps
+### Steps / Rules
+1. Identify task type: create, audit, repair, refactor, migrate, normalize, explain
+2. Ingest source content or raw instructions
+3. Normalize front matter with allowed keys only
+4. Insert path comment `<!-- memory-bank/prompts/<filename>.prompt.md -->`
+5. Add H1 matching filename stem and short opening paragraph
+6. Add slash command H2 `## Slash Command: /<stem> - <purpose>`
+7. Ensure sections in order: Context & Activation; Goal; Output format; Inputs; Steps / Rules; Examples; Edge cases / Stop criteria
+8. Validate filename, header, and slash command alignment
+9. Verify spacing: one blank line after front matter and path comment
+10. Return corrected file or report no changes needed
 
-  1. **Identify task type**
+### Examples
+**Example 1 – Audit and repair**
+_Input:_ Existing malformed prompt file  
+_Output:_ Corrected file matching protocol
 
-    * Classify: create | audit | repair | refactor | migrate | normalize | explain.
-    * If multiple files, process per-file and summarize.
+**Example 2 – Create from raw instructions**
+_Input:_ "Summarize a GitHub issue thread into a 5-bullet action plan"  
+_Output:_ `summarize-thread.prompt.md` with all required sections
 
-  2. **Ingest source**
+### Edge cases / Stop criteria
+- Stop and report if filename is invalid
+- Do nothing if file already compliant
+- Preserve existing `mode`, `model`, or `tools` entries
 
-    * Create: use provided raw instructions.
-    * Audit/refactor: parse the existing `.prompt.md`.
-
-  3. **Normalize front matter**
-
-    * Use `---` fences.
-    * Allowed keys only: `description` (mandatory), `tools` (optional), `mode` (optional), `model` (optional).
-    * Rewrite `description` to a single clear sentence if missing or vague.
-    * Remove all other keys.
-    * Add exactly one empty line after the closing `---`.
-
-  4. **Insert path comment**
-
-    * Add `<!-- memory-bank/prompts/<filename>.prompt.md -->`.
-    * Replace `<filename>` with the exact filename.
-    * Add exactly one empty line after the comment.
-
-  5. **Header and slash command**
-
-    * `# <Verb-first Title>` in Title Case, matching the filename stem.
-    * Next line: `> Slash command: /<filename-stem>`.
-
-  6. **Required sections (in order)**
-
-    * `## Intent`
-    * `## Inputs`
-    * `## Preconditions`
-    * `## Steps`
-    * `## Output Format`
-    * `## Constraints`
-    * `## Failure Modes and Recovery`
-    * `## Examples` (≥2, each with input and expected output)
-
-  7. **Formatting rules (markdownlint)**
-
-    * One blank line before and after every heading and code block.
-    * Hierarchical headings only.
-    * LF newlines.
-    * Max 120 characters per line.
-    * Spaces only; no tabs; no trailing spaces.
-
-  8. **Filename validation**
-
-    * Verb-first, lowercase kebab-case, `.prompt.md` suffix.
-    * Header and slash command match the filename stem.
-    * Treat any `*.prompts.md` file name as a typo; correct to `.prompt.md`. Folder is `prompts/` (plural), file is `prompt` (singular).
-
-  9. **Verification**
-
-    * All required sections exist and are ordered.
-    * Front matter keys are allowed and `description` is unambiguous.
-    * Spacing complies with Step 7.
-
-  10. **Deliverables**
-
-      * Create/repair/refactor/migrate: return the corrected `.prompt.md`.
-      * Audit-only: return an Audit Report followed by the corrected file.
-
-  ## Output Format
-
-  Produce either:
-
-  1. A complete `.prompt.md` that passes this protocol, or
-  2. An audit summary followed by the corrected `.prompt.md`.
-
-  ## Constraints
-
-  * Do not add `tools`, `mode`, or `model` unless provided.
-  * Do not remove provided `tools`, `mode`, or `model`.
-  * Do not introduce conventions not listed here.
-  * All instructions must be imperative and explicit.
-  * Keep exactly one empty line after front matter and after the path comment.
-
-  ## Failure Modes and Recovery
-
-  * **Missing description** → Synthesize a precise one from context.
-  * **Ambiguous description** → Rewrite for clarity and actionability.
-  * **Disallowed front matter keys** → Remove them.
-  * **Formatting violations** → Fix per Step 7.
-  * **Section order wrong or missing** → Reorder and add.
-  * **Filename/header/command mismatch** → Align all three.
-
-  ## Examples
-
-  ### Example 1 – Audit and repair a malformed file
-
-  **Input**
-
-  ```
-  ---
-  description: Make something
-  extra: nope
-  ---
-  # do stuff
-  ```
-
-  **Expected Output**
-
-  A corrected `.prompt.md` with only `description` in front matter, proper path comment, matching header and slash command, all required sections in order, and markdownlint-compliant spacing.
-
-  ### Example 2 – Create from raw instructions
-
-  **Input**
-
-  ```
-  Summarize a GitHub issue thread into a 5-bullet action plan with owners and due dates.
-  ```
-
-  **Expected Output**
-
-  A new `summarize-thread.prompt.md` that defines a precise `description`, includes the path comment, header, and `/summarize-thread`, provides all required sections with imperative steps, and two worked examples.
-
-  ## What to Keep in Mind
-
-  * Protocol: author, audit, refactor, migrate, and maintain `.prompt.md` files in `memory-bank/prompts/`.
-  * Scope: full lifecycle coverage; filename work reduced to validation only.
-  * Location: all files under `memory-bank/prompts/`.
-  * Filename rule: verb-first, lowercase kebab-case, suffix `.prompt.md`; treat any `*.prompts.md` as a typo; folder is `prompts/` plural.
-  * Inputs: required raw instructions or existing `.prompt.md`; optional `description`, `tools`, `mode`, `model` to retain.
-  * Overrides: this protocol supersedes other conventions.
-  * Step 1 — Identify task type: create | audit | repair | refactor | migrate | normalize | explain; handle multi-file per-file.
-  * Step 2 — Ingest source: create→use raw input; audit/refactor→parse existing file.
-  * Step 3 — Normalize front matter: `---` fences; allowed keys only; rewrite concise `description`; remove others; one empty line after.
-  * Step 4 — Insert path comment: `<!-- memory-bank/prompts/<filename>.prompt.md -->`; one empty line after.
-  * Step 5 — Header and slash: `# <Verb-first Title>` matching filename; next line `> Slash command: /<filename-stem>`.
-  * Step 6 — Sections order: Intent; Inputs; Preconditions; Steps; Output Format; Constraints; Failure Modes and Recovery; Examples (≥2).
-  * Step 7 — Formatting rules: blank line around headings and code; hierarchical headings; LF newlines; ≤120 chars/line; spaces only; no trailing spaces.
-  * Step 8 — Filename validation: enforce rule; header and slash command must match filename stem.
-  * Step 9 — Verification: sections present and ordered; allowed front matter; unambiguous description; spacing per rules.
-  * Step 10 — Deliverables: corrected `.prompt.md`; or Audit Report + corrected file.
-  * Output format: either complete compliant file or audit summary followed by corrected file.
-  * Constraints: don’t add `tools`/`mode`/`model` unless provided; don’t remove provided ones; no new conventions; imperative instructions; exactly one empty line after front matter and after path comment.
-  * Failure modes: missing description; ambiguous description; disallowed keys; formatting violations; wrong section order; filename/header/command mismatch.
-  * Recovery actions: synthesize or rewrite description; remove disallowed keys; fix formatting; reorder/add sections; align names.
-  * Examples included: Example 1 (audit/repair malformed file); Example 2 (create from raw instructions).
-
-
-## Tools 
-
-### Todos
-
-Manage a structured todo list to track progress and plan tasks throughout your coding session. Use this tool VERY frequently to ensure task visibility and proper planning.
-
-When to use this tool:
-
-Complex multi-step work requiring planning and tracking
-When user provides multiple tasks or requests (numbered/comma-separated)
-After receiving new instructions that require multiple steps
-BEFORE starting work on any todo (mark as in-progress)
-IMMEDIATELY after completing each todo (mark completed individually)
-When breaking down larger tasks into smaller actionable steps
-To give users visibility into your progress and planning
-When NOT to use:
-
-Single, trivial tasks that can be completed in one step
-Purely conversational/informational requests
-When just reading files or performing simple searches
-CRITICAL workflow:
-
-Plan tasks by writing todo list with specific, actionable items
-Mark ONE todo as in-progress before starting work
-Complete the work for that specific todo
-Mark that todo as completed IMMEDIATELY
-Move to next todo and repeat
-Todo states:
-
-not-started: Todo not yet begun
-in-progress: Currently working (limit ONE at a time)
-completed: Finished successfully
-IMPORTANT: Mark todos completed as soon as they are done. Do not batch completions.
-
----


### PR DESCRIPTION
## Summary
- establish `define-prompt-file.prompt.md` as canonical prompt authoring guide
- archive outdated prompt authoring guides and update references
- record prompt workflow consolidation in memory bank files

## Testing
- `pnpm lint` *(fails: markdownlint errors in unrelated files)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f14e7dbc833198978ce976aeda05